### PR TITLE
Corrected back Aperture

### DIFF
--- a/raytracing/olympus.py
+++ b/raytracing/olympus.py
@@ -54,7 +54,7 @@ class UMPLFN20XW(Objective):
         super(UMPLFN20XW, self).__init__(f=180 / 20,
                                          NA=0.5,
                                          focusToFocusLength=45,
-                                         backAperture=11,
+                                         backAperture=9,
                                          workingDistance=3.5,
                                          label='UMPLFN20XW',
                                          url="https://www.olympus-lifescience.com/en/objectives/lumplfln-w/")

--- a/raytracing/olympus.py
+++ b/raytracing/olympus.py
@@ -54,8 +54,7 @@ class UMPLFN20XW(Objective):
         super(UMPLFN20XW, self).__init__(f=180 / 20,
                                          NA=0.5,
                                          focusToFocusLength=45,
-                                         backAperture=9,
+                                         backAperture=11,
                                          workingDistance=3.5,
                                          label='UMPLFN20XW',
-                                         url="https://www.olympus-lifescience.com/en/objectives/lumplfln-w/#!cms[tab]=%"
-                                                 "2Fobjectives%2Flumplfln-w%2F20xw")
+                                         url="https://www.olympus-lifescience.com/en/objectives/lumplfln-w/")

--- a/raytracing/tests/testObjective.py
+++ b/raytracing/tests/testObjective.py
@@ -1,0 +1,23 @@
+import unittest
+import env # modifies path
+from raytracing import *
+
+inf = float("+inf")
+
+
+class TestObjective(unittest.TestCase):
+    def testCreateObjectiveWithoutArgument(self):
+        with self.assertRaises(Exception) as context:
+            obj = Objective()
+
+    def testCreateObjective(self):
+        obj = Objective(f=180/20, NA=0.5, focusToFocusLength=50, backAperture=12, workingDistance=2)
+        self.assertIsNotNone(obj)
+        path = ImagingPath()
+        path.append(Space(30))
+        path.append(obj)
+        path.append(Space(30))
+        trace = path.trace(Ray())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/raytracing/tests/testObjective.py
+++ b/raytracing/tests/testObjective.py
@@ -18,6 +18,7 @@ class TestObjective(unittest.TestCase):
         path.append(obj)
         path.append(Space(30))
         trace = path.trace(Ray())
+        self.assertTrue(trace.count != 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -1,31 +1,53 @@
 from raytracing import *
 
-inputBeam = GaussianBeam(w=5)
-beamAfterLens = Lens(f=100)*inputBeam
-zo = beamAfterLens.zo
-delta = zo / 100
-path = LaserPath()
-path.append(Lens(f=100))
-path.append(Space(d=100-delta))
-N = 1000
-for i in range(2*N):
-	path.append(Space(d=delta/N))
+class ObjTest(Objective):
+    """ Olympus UMPLanFN 20XW immersion objective
 
-trace = path.trace(inputRay=inputBeam)
+    Immersion not considered at this point.
 
-fig, axes = plt.subplots(figsize=(10, 7))
-axes.set(xlabel='Distance', ylabel='Radius')
-axes.set_xlim(100-delta,100+delta)
+    """
+    def __init__(self):
+        super(ObjTest, self).__init__(f=180 / 20,
+                                         NA=0.5,
+                                         focusToFocusLength=45,
+                                         backAperture=5,
+                                         workingDistance=3.5,
+                                         label='UMPLFN20XW',
+                                         url="https://www.olympus-lifescience.com/en/objectives/lumplfln-w/")
 
-x = []
-y = []
-for q in trace:
-    x.append(q.z)
-    y.append(q.R)
-axes.plot(x, y, 'r', linewidth=1)
-plt.show()
+l = ObjTest()
+path = ImagingPath()
+path.append(Space(10))
+path.append(l)
+path.append(Space(10))
 
-# for beam in trace:
-# 	print(beam.z, beam.R)
+path.display(onlyChiefAndMarginalRays=True)
+# inputBeam = GaussianBeam(w=5)
+# beamAfterLens = Lens(f=100)*inputBeam
+# zo = beamAfterLens.zo
+# delta = zo / 100
+# path = LaserPath()
+# path.append(Lens(f=100))
+# path.append(Space(d=100-delta))
+# N = 1000
+# for i in range(2*N):
+# 	path.append(Space(d=delta/N))
 
-#path.display()
+# trace = path.trace(inputRay=inputBeam)
+
+# fig, axes = plt.subplots(figsize=(10, 7))
+# axes.set(xlabel='Distance', ylabel='Radius')
+# axes.set_xlim(100-delta,100+delta)
+
+# x = []
+# y = []
+# for q in trace:
+#     x.append(q.z)
+#     y.append(q.R)
+# axes.plot(x, y, 'r', linewidth=1)
+# plt.show()
+
+# # for beam in trace:
+# # 	print(beam.z, beam.R)
+
+# #path.display()


### PR DESCRIPTION
I tried to use the UMPLFN20XW objective in a script and it gave me an error. In fact, it seems like a 10.8 mm back aperture or less isn't allowed so I modified it for 11 mm. I will investigate. The UMPLFN20XW objective of the 1.1.9 version of the raytracing module can't be used at the moment.