### PR TITLE
Found a solution for matplotlib to allow ctrl-C in script window

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 import matplotlib.path as mpath
 import matplotlib.transforms as transforms
-
+import sys
 
 class ImagingPath(MatrixGroup):
     """ImagingPath: the main class of the module, allowing
@@ -400,13 +400,15 @@ class ImagingPath(MatrixGroup):
 
         try:
             plt.plot()
-            while True:
+            if sys.platform.startswith('win'):
+                plt.show()
+            else:
                 plt.draw()
-                plt.pause(0.001)
+                while True:
+                    plt.pause(0.001)
 
         except KeyboardInterrupt:
             plt.close()
-
 
     def save(self, filepath,
              limitObjectToFieldOfView=False,

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -398,7 +398,15 @@ class ImagingPath(MatrixGroup):
                                 onlyChiefAndMarginalRays=onlyChiefAndMarginalRays,
                                 removeBlockedRaysCompletely=removeBlockedRaysCompletely)
 
-        plt.show()
+        try:
+            plt.plot()
+            while True:
+                plt.draw()
+                plt.pause(0.001)
+
+        except KeyboardInterrupt:
+            exit(0)
+
 
     def save(self, filepath,
              limitObjectToFieldOfView=False,

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -405,7 +405,7 @@ class ImagingPath(MatrixGroup):
                 plt.pause(0.001)
 
         except KeyboardInterrupt:
-            exit(0)
+            plt.close()
 
 
     def save(self, filepath,

--- a/raytracing/laserpath.py
+++ b/raytracing/laserpath.py
@@ -88,8 +88,14 @@ class LaserPath(MatrixGroup):
 
         self.createBeamTracePlot(axes=axes, beams=beams)
 
-        plt.ioff()
-        plt.show()
+        try:
+            plt.plot()
+            while True:
+                plt.draw()
+                plt.pause(0.001)
+
+        except KeyboardInterrupt:
+            exit(0)
 
     def createBeamTracePlot(self, axes, beams):
         """ Create a matplotlib plot to draw the laser beam and the elements.

--- a/raytracing/laserpath.py
+++ b/raytracing/laserpath.py
@@ -90,9 +90,12 @@ class LaserPath(MatrixGroup):
 
         try:
             plt.plot()
-            while True:
+            if sys.platform.startswith('win'):
+                plt.show()
+            else:
                 plt.draw()
-                plt.pause(0.001)
+                while True:
+                    plt.pause(0.001)
 
         except KeyboardInterrupt:
             plt.close()

--- a/raytracing/laserpath.py
+++ b/raytracing/laserpath.py
@@ -95,7 +95,7 @@ class LaserPath(MatrixGroup):
                 plt.pause(0.001)
 
         except KeyboardInterrupt:
-            exit(0)
+            plt.close()
 
     def createBeamTracePlot(self, axes, beams):
         """ Create a matplotlib plot to draw the laser beam and the elements.

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -563,8 +563,14 @@ class Matrix(object):
         self.drawPointsOfInterest(z=0, axes=axes)
         self.drawPrincipalPlanes(z=0, axes=axes)
 
-        plt.ioff()
-        plt.show()
+        try:
+            plt.plot()
+            while True:
+                plt.draw()
+                plt.pause(0.001)
+
+        except KeyboardInterrupt:
+            exit(0)
 
     def drawAt(self, z, axes, showLabels=False): # pragma: no cover
         """ Draw element on plot with starting edge at 'z'.

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -570,7 +570,7 @@ class Matrix(object):
                 plt.pause(0.001)
 
         except KeyboardInterrupt:
-            exit(0)
+            plt.close()
 
     def drawAt(self, z, axes, showLabels=False): # pragma: no cover
         """ Draw element on plot with starting edge at 'z'.

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -565,10 +565,14 @@ class Matrix(object):
 
         try:
             plt.plot()
-            while True:
+            if sys.platform.startswith('win'):
+                plt.show()
+            else:
                 plt.draw()
-                plt.pause(0.001)
-        except:
+                while True:
+                    plt.pause(0.001)
+
+        except KeyboardInterrupt:
             plt.close()
 
     def drawAt(self, z, axes, showLabels=False): # pragma: no cover

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -568,8 +568,7 @@ class Matrix(object):
             while True:
                 plt.draw()
                 plt.pause(0.001)
-
-        except KeyboardInterrupt:
+        except:
             plt.close()
 
     def drawAt(self, z, axes, showLabels=False): # pragma: no cover

--- a/raytracing/tests/testsAsynchrnousTesting.py
+++ b/raytracing/tests/testsAsynchrnousTesting.py
@@ -1,0 +1,65 @@
+import unittest
+import env # modifies path
+from raytracing import *
+import signal
+import time 
+import os
+
+inf = float("+inf")
+
+_flag = False
+
+def testHandler(signum, frame):
+    TestSignalsAndAsynchronousTesting.flag = True
+
+def sendCtrlCHandler(signum, frame):
+    pid = os.getpid()
+    os.kill(pid, signal.SIGINT)
+
+def raiseKeyboardInterrupt(signum, frame):
+    raise KeyboardInterrupt
+
+class TestSignalsAndAsynchronousTesting(unittest.TestCase):
+    @property
+    def flag(self):
+        return _flag
+
+    def testSignalAsync(self):
+        TestSignalsAndAsynchronousTesting.flag = False
+        signal.signal(signal.SIGALRM, testHandler)
+
+        signal.alarm(1)
+
+        time.sleep(1.1)
+        self.assertTrue(TestSignalsAndAsynchronousTesting.flag)
+
+    def testNoSignalAsync(self):
+        TestSignalsAndAsynchronousTesting.flag = False
+        signal.signal(signal.SIGALRM, testHandler)
+
+        # do nothing
+
+        time.sleep(0.1)
+        self.assertFalse(TestSignalsAndAsynchronousTesting.flag)
+
+    def testSendCtrlC(self):
+        TestSignalsAndAsynchronousTesting.flag = False
+        signal.signal(signal.SIGINT, testHandler)
+
+        pid = os.getpid()
+        os.kill(pid, signal.SIGINT)
+        self.assertTrue(TestSignalsAndAsynchronousTesting.flag)
+
+    def testMatrixDisplayCanQuit(self):
+        signal.signal(signal.SIGALRM, sendCtrlCHandler)
+
+        signal.alarm(1) # send ctrl-c in 1 second
+        m = Matrix()
+        m.display()
+
+        self.assertTrue(True) # if we make it here, we succeeded
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/raytracing/tests/testsMatplotlib.py
+++ b/raytracing/tests/testsMatplotlib.py
@@ -1,0 +1,76 @@
+import unittest
+import env # modifies path
+from raytracing import *
+import signal
+import time 
+import os
+
+inf = float("+inf")
+
+_flag = False
+
+def testHandler(signum, frame):
+    TestSignalsAndAsynchronousTesting.flag = True
+
+def sendCtrlCHandler(signum, frame):
+    signal.signal(signal.SIGALRM, killEverything)
+    signal.alarm(2)
+
+    pid = os.getpid()
+    os.kill(pid, signal.SIGINT)
+
+
+def raiseKeyboardInterrupt(signum, frame):
+    raise KeyboardInterrupt
+
+def alarmAndCancelHandler(signum, frame):
+    signal.signal(signal.SIGALRM, testHandler)
+
+def killEverything(signum, frame):
+    pid = os.getpid()
+    os.kill(pid, signal.SIGKILL)
+
+class TestSignalsAndAsynchronousTesting(unittest.TestCase):
+    @property
+    def flag(self):
+        return _flag
+
+    def testSignalAsync(self):
+        TestSignalsAndAsynchronousTesting.flag = False
+        signal.signal(signal.SIGALRM, testHandler)
+
+        signal.alarm(1)
+
+        time.sleep(1.1)
+        self.assertTrue(TestSignalsAndAsynchronousTesting.flag)
+
+    def testNoSignalAsync(self):
+        TestSignalsAndAsynchronousTesting.flag = False
+        signal.signal(signal.SIGALRM, testHandler)
+
+        # do nothing
+
+        time.sleep(0.1)
+        self.assertFalse(TestSignalsAndAsynchronousTesting.flag)
+
+    def testSendCtrlC(self):
+        TestSignalsAndAsynchronousTesting.flag = False
+        signal.signal(signal.SIGINT, testHandler)
+
+        pid = os.getpid()
+        os.kill(pid, signal.SIGINT)
+        self.assertTrue(TestSignalsAndAsynchronousTesting.flag)
+
+    def testMatrixDisplayCanQuit(self):
+        signal.signal(signal.SIGALRM, sendCtrlCHandler)
+
+        signal.alarm(1) # send ctrl-c in 1 second
+        m = Matrix()
+        m.display()
+
+        self.assertTrue(True) # if we make it here, we succeeded
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Finally found a solution to matplotlib ctrl-C disappearance.

It is fairly simple: use plt.draw() instead of plt.show(), loop and look for interrupts. Done!

Solutions was found here: https://stackoverflow.com/questions/28269157/plotting-in-a-non-blocking-way-with-matplotlib