### PR TITLE
Added a missing import for sys

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -4,7 +4,7 @@ from .rays import *
 
 import multiprocessing
 import copy
-
+import sys
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 import matplotlib.path as mpath


### PR DESCRIPTION
The modified display methods need to know which OS is used, so it requires the sys module. It was not imported.

Other displaying classes require matrix (or matrixgroup, which require matrix) so only matrix need to explicitely import sys.