### PR TITLE
traceManyThroughInParallel is now returning Rays of Ray objects

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -16,10 +16,8 @@ import tempfile
 import warnings
 
 
-
 def warningOnOneLine(message, category, filename, lineno, line=None):
     return ' %s:%s\n%s:%s' % (filename, lineno, category.__name__, message)
-
 
 
 warnings.formatwarning = warningOnOneLine
@@ -352,7 +350,12 @@ class Matrix(object):
 
         with multiprocessing.Pool(processes=processes) as pool:
             outputRays = pool.map(self.traceManyThrough, manyInputRays)
-        return Rays(rays=outputRays)
+
+        outputRaysList = []
+        for rays in outputRays:
+            outputRaysList += rays.rays
+
+        return Rays(rays=outputRaysList)
 
     def traceManyThroughInParallelNoChunks(self, inputRays, progress=True, processes=None):
         if processes is None:
@@ -362,6 +365,7 @@ class Matrix(object):
 
         with multiprocessing.Pool(processes=processes) as pool:
             outputRays = pool.map(self.traceThrough, manyInputRays)
+            print(outputRays)
         return Rays(rays=outputRays)
 
     @property


### PR DESCRIPTION
It was initially returning Rays of Ray because of the way mapping was done:

1. Input rays were split in X sublists for processing (list of lists)
2. Mapping was done on a list of list of rays with traceManyThrough
3. traceManyThrough returns a Rays object
4. Pool's mapping returns a list with the results (hence a list of Rays).

Because of that, Pool's map is returning a list of Rays, then that list was given to Rays, but Rays take as input a list of Ray objects, not a list of Rays object; methods don't work with a list of Rays.
traceManyThroughInParallelNoChunks doesn't have the same issue, because it works with the mapping of a list of Ray objects, not a list of lists.