### PR TITLE
Fix flip issue#86

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -848,6 +848,16 @@ class CurvedMirror(Matrix):
 
         return pointsOfInterest
 
+    def flipOrientation(self):
+        """ We flip the element around (as in, we turn a lens around front-back).
+        In this case, R -> -R.  It is important to call the
+        super implementation because other things must be flipped (vertices for instance)
+        """
+        super(CurvedMirror, self).flipOrientation()
+
+        self.C = - self.C
+        return self
+
 
 class Space(Matrix):
     """Free space of length d
@@ -1076,7 +1086,7 @@ class ThickLens(Matrix):
         In this case, R1 = -R2, and R2 = -R1.  It is important to call the
         super implementation because other things must be flipped (vertices for instance)
         """
-        super(DielectricInterface, self).flipOrientation()
+        super(ThickLens, self).flipOrientation()
 
         temp = self.R1
         self.R1 = -self.R2

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1071,6 +1071,26 @@ class ThickLens(Matrix):
 
         return pointsOfInterest
 
+    def flipOrientation(self):
+        """ We flip the element around (as in, we turn a lens around front-back).
+        In this case, R1 = -R2, and R2 = -R1.  It is important to call the
+        super implementation because other things must be flipped (vertices for instance)
+        """
+        super(DielectricInterface, self).flipOrientation()
+
+        temp = self.R1
+        self.R1 = -self.R2
+        self.R2 = -temp
+
+        R1 = self.R1
+        R2 = self.R2
+        t = self.L
+
+        self.A = t * (1.0 - n) / (n * R1) + 1
+        self.B = t / n
+        self.C = - (n - 1.0) * (1.0 / R1 - 1.0 / R2 + t * (n - 1.0) / (n * R1 * R2))
+        self.D = t * (n - 1.0) / (n * R2) + 1
+        return self
 
 class DielectricSlab(ThickLens):
     """A slab of dielectric material of index n and length d, with flat faces

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1095,7 +1095,8 @@ class ThickLens(Matrix):
         R1 = self.R1
         R2 = self.R2
         t = self.L
-
+        n = self.n
+        
         self.A = t * (1.0 - n) / (n * R1) + 1
         self.B = t / n
         self.C = - (n - 1.0) * (1.0 / R1 - 1.0 / R2 + t * (n - 1.0) / (n * R1 * R2))

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -167,7 +167,7 @@ class Matrix(object):
         """
         q = rightSideBeam.q
         if rightSideBeam.n != self.frontIndex:
-            msg = "The gaussian beam is not tracking the index of refraction properly {0} {1}".format(
+            msg = "The gaussian beam is not tracking the index of refraction properly {0} {1}\n".format(
                 rightSideBeam.n, self.frontIndex)
             warnings.warn(msg, UserWarning)
 
@@ -821,12 +821,16 @@ class Lens(Matrix):
 
 
 class CurvedMirror(Matrix):
-    """A curved mirror of radius R and infinite or finite diameter
-
+    """A curved mirror of radius R and infinite or finite diameter.
+    Note that a concave mirror (i.e. converging mirror) has a negative
+    radius of curvature if we want to keep the same sign convention.
+    (there was a mistake up to version 1.2.7 of the module)
     """
 
     def __init__(self, R, diameter=float('+Inf'), label=''):
-        super(CurvedMirror, self).__init__(A=1, B=0, C=-2 / float(R), D=1,
+        warnings.warn("The sign of the radius of curvature in CurvedMirror was changed \
+in version 1.2.8 to maintain the sign convention\n",UserWarning)
+        super(CurvedMirror, self).__init__(A=1, B=0, C=2 / float(R), D=1,
                                            physicalLength=0,
                                            apertureDiameter=diameter,
                                            frontVertex=0,
@@ -1096,7 +1100,7 @@ class ThickLens(Matrix):
         R2 = self.R2
         t = self.L
         n = self.n
-        
+
         self.A = t * (1.0 - n) / (n * R1) + 1
         self.B = t / n
         self.C = - (n - 1.0) * (1.0 / R1 - 1.0 / R2 + t * (n - 1.0) / (n * R1 * R2))

--- a/raytracing/tests/testsCurvedMirror.py
+++ b/raytracing/tests/testsCurvedMirror.py
@@ -1,0 +1,38 @@
+import unittest
+import envtest # modifies path
+from raytracing import *
+import warnings
+
+inf = float("+inf")
+
+
+class TestCurvedMirror(unittest.TestCase):
+    def testMatrix(self):
+        m = CurvedMirror(R=-10)
+        self.assertIsNotNone(m)
+
+    def testRayInMirror(self):
+        m1 = CurvedMirror(R=-10)
+        outRay1 = m1*Ray(y=1,theta=0)
+        self.assertTrue(outRay1.theta > 0)
+
+        m2 = CurvedMirror(R=10)
+        outRay2 = m2*Ray(y=1,theta=0)
+        self.assertTrue(outRay2.theta <  0)
+
+    def testRayInFlippedMirror(self):
+        m1 = CurvedMirror(R=-10)
+        outRay1 = m1*Ray(y=1,theta=0)
+        m2 = CurvedMirror(R=10)
+        outRay2 = m2*Ray(y=1,theta=0)
+
+        m3 = m2.flipOrientation()
+        outRay3 = m3*Ray(y=1,theta=0)
+
+        self.assertEqual(outRay3.theta, outRay1.theta)
+        self.assertEqual(outRay3.theta, -outRay2.theta)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -314,6 +314,41 @@ class TestMatrix(unittest.TestCase):
         self.assertAlmostEqual(m1.B, m2.B,4)
         self.assertAlmostEqual(m1.C, m2.C,4)
         self.assertAlmostEqual(m1.D, m2.D,4)
+
+    def testConvergingCurvedMirror(self):
+        # Concave should be positive?
+        m = CurvedMirror(R=-100)
+        outRayDown = m*Ray(y=1,theta=0)
+        outRayUp = m*Ray(y=-1,theta=0)
+
+        # Ray is focussed to focal spot
+        self.assertTrue(m.C < 0)
+        self.assertTrue(outRayDown.theta < 0)
+        self.assertTrue(outRayUp.theta > 0)
+
+    def testDivergingCurvedMirror(self):
+        m = CurvedMirror(R=100)
+        outRayUp = m*Ray(y=1,theta=0)
+        outRayDown = m*Ray(y=-1,theta=0)
+
+        # Ray is diverging
+        self.assertTrue(m.C > 0)
+        self.assertTrue(outRayDown.theta < 0)
+        self.assertTrue(outRayUp.theta > 0)
+
+    def testCurvedMirrorFlip(self):
+        # Biconvex
+        m1 = CurvedMirror(R=100)
+        m2 = CurvedMirror(R=-100)
+        m2.flipOrientation()
+
+        self.assertAlmostEqual(m1.determinant, 1,4)
+        self.assertAlmostEqual(m2.determinant, 1,4)
+        self.assertAlmostEqual(m1.A, m2.A,4)
+        self.assertAlmostEqual(m1.B, m2.B,4)
+        self.assertAlmostEqual(m1.C, m2.C,4)
+        self.assertAlmostEqual(m1.D, m2.D,4)
+
     def testLensFocalLengths(self):
         m = Lens(f=5)
         self.assertEqual(m.effectiveFocalLengths(), (5, 5))

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -302,6 +302,18 @@ class TestMatrix(unittest.TestCase):
         self.assertAlmostEqual(m.C, mEquivalent.C,3)
         self.assertAlmostEqual(m.D, mEquivalent.D,3)
 
+    def testThickConvergingLensFlip(self):
+        # Biconvex
+        m1 = ThickLens(n=1.55, R1=200, R2=-100, thickness=3)
+        m2 = ThickLens(n=1.55, R1=100, R2=-200, thickness=3)
+        m2.flipOrientation()
+
+        self.assertAlmostEqual(m1.determinant, 1,4)
+        self.assertAlmostEqual(m2.determinant, 1,4)
+        self.assertAlmostEqual(m1.A, m2.A,4)
+        self.assertAlmostEqual(m1.B, m2.B,4)
+        self.assertAlmostEqual(m1.C, m2.C,4)
+        self.assertAlmostEqual(m1.D, m2.D,4)
     def testLensFocalLengths(self):
         m = Lens(f=5)
         self.assertEqual(m.effectiveFocalLengths(), (5, 5))

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -246,6 +246,62 @@ class TestMatrix(unittest.TestCase):
         self.assertEqual(m.frontVertex, 0)
         self.assertEqual(m.backVertex, 0)
 
+    def testDielectricInterfaceConvergingSign(self):
+        # Positive R is convex for ray
+        m = DielectricInterface(n1=1, n2=1.5, R=10)
+        outRayDown = m*Ray(y=1,theta=0)
+        outRayUp = m*Ray(y=-1,theta=0)
+
+        # Ray is focussed to focal spot
+        self.assertTrue(outRayDown.theta < 0)
+        self.assertTrue(outRayUp.theta > 0)
+
+    def testDielectricInterfaceDivergingSign(self):
+        # Negative R is concave for ray
+        m = DielectricInterface(n1=1, n2=1.5, R=-10)
+        outRayUp = m*Ray(y=1,theta=0)
+        outRayDown = m*Ray(y=-1,theta=0)
+
+        # Ray is diverging
+        self.assertTrue(outRayDown.theta < 0)
+        self.assertTrue(outRayUp.theta > 0)
+
+    def testThickConvergingLens(self):
+        # Biconvex
+        m = ThickLens(n=1.55, R1=100, R2=-100, thickness=3)
+        outRayDown = m*Ray(y=1,theta=0)
+        outRayUp = m*Ray(y=-1,theta=0)
+
+        # Ray is focussed to focal spot
+        self.assertTrue(m.C < 0)
+        self.assertTrue(outRayDown.theta < 0)
+        self.assertTrue(outRayUp.theta > 0)
+
+    def testThickDivergingLens(self):
+        # Biconcave
+        m = ThickLens(n=1.55, R1=-100, R2=100, thickness=3)
+        outRayUp = m*Ray(y=1,theta=0)
+        outRayDown = m*Ray(y=-1,theta=0)
+
+        # Ray is diverging
+        self.assertTrue(m.C > 0)
+        self.assertTrue(outRayDown.theta < 0)
+        self.assertTrue(outRayUp.theta > 0)
+
+    def testThickConvergingLensEquivalence(self):
+        # Biconvex
+        m = ThickLens(n=1.55, R1=100, R2=-100, thickness=3)
+
+        mEquivalent = MatrixGroup()
+        mEquivalent.append(DielectricInterface(n1=1, n2=1.55, R=100))
+        mEquivalent.append(Space(d=3))
+        mEquivalent.append(DielectricInterface(n1=1.55, n2=1.0, R=-100))
+
+        self.assertAlmostEqual(m.A, mEquivalent.A,3)
+        self.assertAlmostEqual(m.B, mEquivalent.B,3)
+        self.assertAlmostEqual(m.C, mEquivalent.C,3)
+        self.assertAlmostEqual(m.D, mEquivalent.D,3)
+
     def testLensFocalLengths(self):
         m = Lens(f=5)
         self.assertEqual(m.effectiveFocalLengths(), (5, 5))

--- a/raytracing/tests/testsThickLens.py
+++ b/raytracing/tests/testsThickLens.py
@@ -1,0 +1,39 @@
+import unittest
+import envtest # modifies path
+from raytracing import *
+import warnings
+
+inf = float("+inf")
+
+
+class TestThickLens(unittest.TestCase):
+    def testMatrix(self):
+        m = ThickLens(R1=-10, R2 = 20, n=1.5, thickness=1)
+        self.assertIsNotNone(m)
+
+    def testRayConvergingThickLens(self):
+        m1 = ThickLens(R1=-10, R2 = 20, n=1.5, thickness=1)
+        outRay1 = m1*Ray(y=1,theta=0)
+        self.assertTrue(outRay1.theta < 0)
+
+    def testRayDivergingThickLens(self):
+        m2 = ThickLens(R1=10, R2 = -20, n=1.5, thickness=1)
+        outRay2 = m2*Ray(y=1,theta=0)
+        self.assertTrue(outRay2.theta >  0)
+
+    def testRayInFlippedThickLens(self):
+        m1 = CurvedMirror(R=-10)
+        outRay1 = m1*Ray(y=1,theta=0)
+        m2 = CurvedMirror(R=10)
+        outRay2 = m2*Ray(y=1,theta=0)
+
+        m3 = m2.flipOrientation()
+        outRay3 = m3*Ray(y=1,theta=0)
+
+        self.assertEqual(outRay3.theta, outRay1.theta)
+        self.assertEqual(outRay3.theta, -outRay2.theta)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added flipOreintation override to ThickLens() and CurvedMirror(): made sure that the super implementation is called, because the base class manages the details.