### PR TITLE
Backward conjugate in entrance pupil raised AttributeError

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -153,8 +153,11 @@ class ImagingPath(MatrixGroup):
             (stopPosition, stopDiameter) = self.apertureStop()
             transferMatrixToApertureStop = self.transferMatrix(upTo=stopPosition)
             (pupilPosition, matrixToPupil) = transferMatrixToApertureStop.backwardConjugate()
-            (Mt, Ma) = matrixToPupil.magnification()
-            return (-pupilPosition, stopDiameter / Mt)
+            if matrixToPupil is None:
+                return None, None
+            else:
+                (Mt, Ma) = matrixToPupil.magnification()
+                return (-pupilPosition, stopDiameter / Mt)
         else:
             return (None, None)
 

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -20,6 +20,14 @@ class TestImagingPath(unittest.TestCase):
         path.append(Aperture(diameter=20))
         self.assertAlmostEqual(path.fieldOfView(), 20, 2)
 
+    def testEntrancePupilAIs0(self):
+        space = Space(2)
+        lens = Lens(10, 110)
+        space2 = Space(10, diameter=50)
+        elements = [space, lens, space2]
+        path = ImagingPath(elements)
+        self.assertIsNotNone(path.entrancePupil())
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See [this issue](https://github.com/DCC-Lab/RayTracing/issues/94) for more *in depth* info about the associated issue. I quickly fixed the problem by checking if the transfer matrix to the pupil is `None` because it causes an `AttributeError` when we tried to get the magnification of the `NoneType` object.

We can also raise another exception when this happens and then explain the problem, but in most cases of an absence of something (aperture stop, backward conjugate, magnification, etc.) we simply return `(None, None)`.