### PR TITLE
Empty matrixGroup now returns 'infinity' as largest diameter

### DIFF
--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -141,8 +141,10 @@ class MatrixGroup(Matrix):
 
     def largestDiameter(self):
         """ Largest finite diameter in all elements """
+        if len(self.elements) == 0:
+            return float("+inf")
 
-        maxDiameter = float("+inf")
+        maxDiameter = 0
         if self.hasFiniteApertureDiameter():
             for element in self.elements:
                 diameter = element.largestDiameter()

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -141,8 +141,6 @@ class MatrixGroup(Matrix):
 
     def largestDiameter(self):
         """ Largest finite diameter in all elements """
-        if len(self.elements) == 0:
-            return float("+inf")
 
         maxDiameter = 0
         if self.hasFiniteApertureDiameter():
@@ -152,6 +150,8 @@ class MatrixGroup(Matrix):
                     maxDiameter = diameter
         elif len(self.elements) != 0:
             maxDiameter = self.elements[0].displayHalfHeight() * 2
+        else:
+            maxDiameter = float("+inf")
 
         return maxDiameter
 

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -141,6 +141,10 @@ class MatrixGroup(Matrix):
     def largestDiameter(self):
         """ Largest finite diameter in all elements """
 
+        if len(self.elements) == 0:
+            # No elements -> no aperture -> infinite diameter
+            return float("+inf")
+
         maxDiameter = 0.0
         if self.hasFiniteApertureDiameter():
             for element in self.elements:

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -6,6 +6,7 @@ import matplotlib.patches as patches
 import matplotlib.path as mpath
 import matplotlib.transforms as transforms
 
+
 class MatrixGroup(Matrix):
     """MatrixGroup: A group of Matrix(), allowing
     the combination of several elements to be treated as a 
@@ -13,7 +14,7 @@ class MatrixGroup(Matrix):
     """
 
     def __init__(self, elements=None, label=""):
-        super(MatrixGroup, self).__init__(1,0,0,1,label=label)
+        super(MatrixGroup, self).__init__(1, 0, 0, 1, label=label)
 
         self.elements = []
 
@@ -141,11 +142,7 @@ class MatrixGroup(Matrix):
     def largestDiameter(self):
         """ Largest finite diameter in all elements """
 
-        if len(self.elements) == 0:
-            # No elements -> no aperture -> infinite diameter
-            return float("+inf")
-
-        maxDiameter = 0.0
+        maxDiameter = float("+inf")
         if self.hasFiniteApertureDiameter():
             for element in self.elements:
                 diameter = element.largestDiameter()
@@ -199,7 +196,6 @@ class MatrixGroup(Matrix):
             else:
                 labels[zStr] = label
 
-
         # Points of interest for each element
         for element in self.elements:
             pointsOfInterest = element.pointsOfInterest(zElement)
@@ -213,9 +209,9 @@ class MatrixGroup(Matrix):
                     labels[zStr] = label
             zElement += element.L
 
-        halfHeight = self.largestDiameter()/2
+        halfHeight = self.largestDiameter() / 2
         for zStr, label in labels.items():
             z = float(zStr)
             axes.annotate(label, xy=(z, 0.0), xytext=(z, -halfHeight * 0.5),
-                         xycoords='data', fontsize=12,
-                         ha='center', va='bottom')
+                          xycoords='data', fontsize=12,
+                          ha='center', va='bottom')

--- a/raytracing/tests/testsMatrixGroup.py
+++ b/raytracing/tests/testsMatrixGroup.py
@@ -3,9 +3,11 @@ from raytracing import *
 
 
 class TestMatrixGroup(unittest.TestCase):
+
+
     def testLargestDiameterWithEmptyGroup(self):
         m = MatrixGroup()
-        self.assertEqual(m.largestDiameter(), 0)
+        self.assertEqual(m.largestDiameter(), float("+inf"))
 
     def testLargestDiameterWithFiniteLens(self):
         m = MatrixGroup(elements=[Lens(f=5, diameter=10)])


### PR DESCRIPTION
When a matrix group is empty (no matrix/component), its largest diameter is infinity (no aperture). Fixes #91 .