### PR TITLE
Update __main__.py

### DIFF
--- a/raytracing/__main__.py
+++ b/raytracing/__main__.py
@@ -3,9 +3,9 @@ from .laserpath import *
 
 from .specialtylenses import *
 from .axicon import *
-import raytracing.thorlabs as thorlabs
-import raytracing.eo as eo
-import raytracing.olympus as olympus
+from . import thorlabs
+from . import eo
+from . import olympus
 
 import argparse
 ap = argparse.ArgumentParser(prog='python -m raytracing')


### PR DESCRIPTION
Relative imports have been added for `eo`, `thorlabs` and `olympus` lenses instead of absolute imports.  The old syntax was implicitly relative in Python 2 only.