### PR TITLE
Relative imports in __main__.py and __init__.py

### DIFF
--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -82,9 +82,9 @@ from .components import *
 from .specialtylenses import *
 from .axicon import *
 
-import raytracing.thorlabs as thorlabs
-import raytracing.eo as eo
-import raytracing.olympus as olympus
+from . import thorlabs
+from . import eo
+from . import olympus
 
 """ Synonym of Matrix: Element 
 

--- a/raytracing/__main__.py
+++ b/raytracing/__main__.py
@@ -3,9 +3,9 @@ from .laserpath import *
 
 from .specialtylenses import *
 from .axicon import *
-import raytracing.thorlabs as thorlabs
-import raytracing.eo as eo
-import raytracing.olympus as olympus
+from . import thorlabs
+from . import eo
+from . import olympus
 
 import argparse
 ap = argparse.ArgumentParser(prog='python -m raytracing')


### PR DESCRIPTION
`thorlabs`, `eo` and `olympus` are now imported via a relative path.