### PR TITLE
Matrix's forwardConjugate and backwardConjugate seem more coherent

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -528,7 +528,7 @@ class Matrix(object):
 
         """
         if self.A == 0:
-            return (None, None)
+            return (float("+inf"), None)
         distance = -self.B / self.A
         conjugateMatrix = self * Space(d=distance)
         return (distance, conjugateMatrix)

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -429,7 +429,7 @@ class TestMatrix(unittest.TestCase):
 
     def testInfiniteBackConjugate(self):
         m = Matrix(A=0)
-        self.assertTupleEqual(m.backwardConjugate(), (None, None))
+        self.assertTupleEqual(m.backwardConjugate(), (float("+inf"), None))
 
     def testFiniteBackConjugate(self):
         m1 = Space(d=10) * Lens(f=5)


### PR DESCRIPTION
I changed the distance from `None` to `float("+inf")` because it "feels more right", the conjugate is at infinity.

This pull request is mostly to get a better understanding of `forwardConjugate()` and `backwardConjugate()`. Like I mentionned in issue #127, both methods have different outputs even if their content is mostly similar (the physical concept of backward/forward conjugate is mostly the same). I changed the output of `backwardConjugate()`: in the case where `A == 0`, the distance returned was `None`. Now it is `float("+inf")`. I still don't know if it should be `float("+inf")` or `float("-inf")`.

Maybe it is better to return `None`. It that case, I think both should return `None`.