### PR TITLE
Fixed problems with Rays histogram methods

### DIFF
--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -170,6 +170,12 @@ class Rays:
         self._thetaHistogram = None
         self._directionBinEdges = None
 
+        self._countHistogramParameters = None
+        self._xValuesCountHistogram = None
+
+        self._anglesHistogramParameters = None
+        self._xValuesAnglesHistogram = None
+
     def load(self, filePath, append=False):
         with open(filePath, 'rb') as infile:
             loadedRays = pickle.Unpickler(infile).load()

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -29,6 +29,12 @@ class Rays:
         self._thetaHistogram = None
         self._directionBinEdges = None
 
+        self._countHistogramParameters = None
+        self._xValuesCountHistogram = None
+
+        self._anglesHistogramParameters = None
+        self._xValuesAnglesHistogram = None
+
     def __len__(self) -> int:
         if self.rays is None:
             return 0
@@ -53,15 +59,17 @@ class Rays:
         return self._thetaValues
 
     def rayCountHistogram(self, binCount=None, minValue=None, maxValue=None):
-        if self._yHistogram is None:
-            if binCount is None:
-                binCount = 40
 
-            if minValue is None:
-                minValue = min(self.yValues)
+        if binCount is None:
+            binCount = 40
 
-            if maxValue is None:
-                maxValue = max(self.yValues)
+        if minValue is None:
+            minValue = min(self.yValues)
+
+        if maxValue is None:
+            maxValue = max(self.yValues)
+
+        if self._countHistogramParameters != (binCount, minValue, maxValue):
 
             (self._yHistogram, binEdges) = histogram(self.yValues,
                                                      bins=binCount,
@@ -70,27 +78,30 @@ class Rays:
             xValues = []
             for i in range(len(binEdges) - 1):
                 xValues.append((binEdges[i] + binEdges[i + 1]) / 2)
+            self._xValuesCountHistogram = xValues
 
-        return (xValues, self._yHistogram)
+        return (self._xValuesCountHistogram, self._yHistogram)
 
     def rayAnglesHistogram(self, binCount=None, minValue=None, maxValue=None):
-        if self._thetaHistogram is None:
-            if binCount is None:
-                binCount = 40
+        if binCount is None:
+            binCount = 40
 
-            if minValue is None:
-                minValue = min(self.thetaValues)
+        if minValue is None:
+            minValue = min(self.thetaValues)
 
-            if maxValue is None:
-                maxValue = max(self.thetaValues)
+        if maxValue is None:
+            maxValue = max(self.thetaValues)
+
+        if self._anglesHistogramParameters != (binCount, minValue, maxValue):
 
             (self._thetaHistogram, binEdges) = histogram(self.thetaValues, bins=binCount, range=(minValue, maxValue))
             self._thetaHistogram = list(self._thetaHistogram)
             xValues = []
             for i in range(len(binEdges) - 1):
                 xValues.append((binEdges[i] + binEdges[i + 1]) / 2)
+            self._xValuesAnglesHistogram = xValues
 
-        return (xValues, self._thetaHistogram)
+        return (self._xValuesAnglesHistogram, self._thetaHistogram)
 
     def display(self, title="Intensity profile", showTheta=True):
         plt.ioff()

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -1,0 +1,22 @@
+import unittest
+import envtest  # modifies path
+from raytracing import *
+
+inf = float("+inf")
+
+
+class TestRays(unittest.TestCase):
+
+    def testRayCountHist(self):
+        r = Rays([Ray()])
+        self.assertIsNotNone(r.rayCountHistogram())  # First time compute
+        self.assertIsNotNone(r.rayCountHistogram())  # Second time compute, doesn't work
+
+    def testRayAnglesHist(self):
+        r = Rays([Ray()])
+        self.assertIsNotNone(r.rayAnglesHistogram())  # First time compute
+        self.assertIsNotNone(r.rayAnglesHistogram())  # Second time compute, doesn't work
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -9,13 +9,25 @@ class TestRays(unittest.TestCase):
 
     def testRayCountHist(self):
         r = Rays([Ray()])
-        self.assertIsNotNone(r.rayCountHistogram())  # First time compute
-        self.assertIsNotNone(r.rayCountHistogram())  # Second time compute, doesn't work
+        init = r.rayCountHistogram()
+        self.assertIsNotNone(init)  # First time compute
+        final = r.rayCountHistogram()
+        self.assertIsNotNone(final)  # Second time compute, now works
+
+        self.assertTupleEqual(init, final)
+        final = r.rayCountHistogram(10)
+        self.assertNotEqual(init, final)
 
     def testRayAnglesHist(self):
         r = Rays([Ray()])
-        self.assertIsNotNone(r.rayAnglesHistogram())  # First time compute
-        self.assertIsNotNone(r.rayAnglesHistogram())  # Second time compute, doesn't work
+        init = r.rayAnglesHistogram()
+        self.assertIsNotNone(init)  # First time compute
+        final = r.rayAnglesHistogram()
+        self.assertIsNotNone(final)  # Second time compute, now works
+
+        self.assertTupleEqual(init, final)
+        final = r.rayAnglesHistogram(10)
+        self.assertNotEqual(init, final)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When we computed `rayCountHistogram()` and `rayAnglesHistogram()` for the first time, it was working perfectly, but when we tried it a second time, it was not working. See issue #132 for more info on why it was not working.

I added new intern variables related to histogram computation, nothing major.

Fixes #132 