### PR TITLE
Rays only accepts interables of Ray instances

### DIFF
--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -20,10 +20,10 @@ class Rays:
             try:
                 inputOk = all([isinstance(ray, Ray) for ray in rays])
             except TypeError:  # The object is not iterable
-                raise AttributeError("'rays' parameter must be iterable (i.e. a list or a tuple).")
+                raise TypeError("'rays' parameter must be iterable (i.e. a list or a tuple).")
 
             if not inputOk:
-                raise AttributeError("'rays' parameter must contain Ray instances only.")
+                raise TypeError("'rays' parameter must contain Ray instances only.")
             self.rays = list(rays)
 
         self.iteration = 0

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -167,6 +167,8 @@ class Rays:
         return self.rays[item]
 
     def append(self, ray):
+        if not isinstance(ray, Ray):
+            raise TypeError("'ray' must be a 'Ray' object.")
         if self.rays is not None:
             self.rays.append(ray)
 

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -24,7 +24,7 @@ class Rays:
 
             if not inputOk:
                 raise AttributeError("'rays' parameter must contain Ray instances only.")
-            self.rays = rays
+            self.rays = list(rays)
 
         self.iteration = 0
         self.progressLog = 10000

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -17,6 +17,13 @@ class Rays:
         if rays is None:
             self.rays = []
         else:
+            try:
+                inputOk = all([isinstance(ray, Ray) for ray in rays])
+            except TypeError:  # The object is not iterable
+                raise AttributeError("'rays' parameter must be iterable (i.e. a list or a tuple).")
+
+            if not inputOk:
+                raise AttributeError("'rays' parameter must contain Ray instances only.")
             self.rays = rays
 
         self.iteration = 0

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -21,19 +21,16 @@ class TestRays(unittest.TestCase):
         self.assertListEqual(Rays(rays).rays, listOfRays)
 
         with self.assertRaises(TypeError) as error:
-            # This should raise an exception
+            # This should raise an TypeError exception
             Rays("Ray(), Ray(1), Ray(1,1)")
-        self.assertEqual(str(error.exception), "'rays' parameter must contain Ray instances only.")
 
         with self.assertRaises(TypeError) as error:
-            # This should raise an exception
+            # This should raise an TypeError exception
             Rays([Ray(), [1, 2], Ray()])
-        self.assertEqual(str(error.exception), "'rays' parameter must contain Ray instances only.")
 
-        with self.assertRaises(AttributeError) as error:
-            # This should raise an exception
+        with self.assertRaises(TypeError) as error:
+            # This should raise an TypeError exception
             Rays(Matrix())
-        self.assertEqual(str(error.exception), "'rays' parameter must be iterable (i.e. a list or a tuple).")
 
     def testRayCountHist(self):
         r = Rays([Ray()])

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -7,6 +7,21 @@ inf = float("+inf")
 
 class TestRays(unittest.TestCase):
 
+    def testRaysInitDifferentInputs(self):
+        listOfRays = [Ray(), Ray(1, 1), Ray(1, -2), Ray(0, -1)]
+        tupleOfRays = tuple(listOfRays)
+        npArrayOfRays = array(listOfRays)
+        raysFromList = Rays(listOfRays)
+        raysFromTuple = Rays(tupleOfRays)
+        raysFromArray = Rays(npArrayOfRays)
+        self.assertListEqual(raysFromList.rays, listOfRays)
+        self.assertTupleEqual(raysFromTuple.rays, tupleOfRays)
+        self.assertTrue(all(raysFromArray.rays == npArrayOfRays))
+
+        with self.assertRaises(Exception):
+            # This should raise an exception
+            Rays("Ray(), Ray(1), Ray(1,1)")
+
     def testRayCountHist(self):
         r = Rays([Ray()])
         init = r.rayCountHistogram()

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -16,9 +16,9 @@ class TestRays(unittest.TestCase):
         raysFromArray = Rays(npArrayOfRays)
         rays = Rays(listOfRays)
         self.assertListEqual(raysFromList.rays, listOfRays)
-        self.assertTupleEqual(raysFromTuple.rays, tupleOfRays)
-        self.assertTrue(all(raysFromArray.rays == npArrayOfRays))
-        self.assertIsNotNone(Rays(rays))
+        self.assertListEqual(raysFromTuple.rays, listOfRays)
+        self.assertListEqual(raysFromArray.rays, listOfRays)
+        self.assertListEqual(Rays(rays).rays, listOfRays)
 
         with self.assertRaises(AttributeError) as error:
             # This should raise an exception

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -14,13 +14,26 @@ class TestRays(unittest.TestCase):
         raysFromList = Rays(listOfRays)
         raysFromTuple = Rays(tupleOfRays)
         raysFromArray = Rays(npArrayOfRays)
+        rays = Rays(listOfRays)
         self.assertListEqual(raysFromList.rays, listOfRays)
         self.assertTupleEqual(raysFromTuple.rays, tupleOfRays)
         self.assertTrue(all(raysFromArray.rays == npArrayOfRays))
+        self.assertIsNotNone(Rays(rays))
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(AttributeError) as error:
             # This should raise an exception
             Rays("Ray(), Ray(1), Ray(1,1)")
+        self.assertEqual(str(error.exception), "'rays' parameter must contain Ray instances only.")
+
+        with self.assertRaises(AttributeError) as error:
+            # This should raise an exception
+            Rays([Ray(), [1, 2], Ray()])
+        self.assertEqual(str(error.exception), "'rays' parameter must contain Ray instances only.")
+
+        with self.assertRaises(AttributeError) as error:
+            # This should raise an exception
+            Rays(Matrix())
+        self.assertEqual(str(error.exception), "'rays' parameter must be iterable (i.e. a list or a tuple).")
 
     def testRayCountHist(self):
         r = Rays([Ray()])

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -20,12 +20,12 @@ class TestRays(unittest.TestCase):
         self.assertListEqual(raysFromArray.rays, listOfRays)
         self.assertListEqual(Rays(rays).rays, listOfRays)
 
-        with self.assertRaises(AttributeError) as error:
+        with self.assertRaises(TypeError) as error:
             # This should raise an exception
             Rays("Ray(), Ray(1), Ray(1,1)")
         self.assertEqual(str(error.exception), "'rays' parameter must contain Ray instances only.")
 
-        with self.assertRaises(AttributeError) as error:
+        with self.assertRaises(TypeError) as error:
             # This should raise an exception
             Rays([Ray(), [1, 2], Ray()])
         self.assertEqual(str(error.exception), "'rays' parameter must contain Ray instances only.")


### PR DESCRIPTION
`Rays.__init__()` was accepting every possible object and this would lead to *unexpected* outcomes in other methods. Now, it only accepts iterables (like a `list` or a *NumPy* `array`) and their content must be `Ray` instances. 
Fixes #134.