### PR TITLE
Changed to NotImplementedError in RandomRays

### DIFF
--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -288,9 +288,9 @@ class RandomRays(Rays):
 
     def __getitem__(self, item):
         if self.rays is None:
-            raise NotImplemented("You cannot access RandomRays")
+            raise NotImplementedError("You cannot access RandomRays")
         elif len(self.rays) < item:
-            raise NotImplemented("You cannot access RandomRays")
+            raise NotImplementedError("You cannot access RandomRays")
         else:
             return self.rays[item]
 
@@ -301,7 +301,7 @@ class RandomRays(Rays):
         return self.randomRay()
 
     def randomRay(self) -> Ray:
-        raise NotImplemented("You must implement randomRay() in your subclass")
+        raise NotImplementedError("You must implement randomRay() in your subclass")
 
 
 class RandomUniformRays(RandomRays):

--- a/raytracing/tests/testsRaysSubclasses.py
+++ b/raytracing/tests/testsRaysSubclasses.py
@@ -1,0 +1,14 @@
+import unittest
+import envtest  # modifies path
+from raytracing import *
+
+inf = float("+inf")
+
+
+class TestRandomRays(unittest.TestCase):
+
+    def testRandomRay(self):
+        rays = RandomRays()  # We keep default value, we are not intersted in the construction of a specific object
+        with self.assertRaises(NotImplementedError):
+            # This raises an exception, because with call a constant (i.e. constant(something))
+            rays.randomRay()

--- a/raytracing/tests/testsRaysSubclasses.py
+++ b/raytracing/tests/testsRaysSubclasses.py
@@ -10,5 +10,5 @@ class TestRandomRays(unittest.TestCase):
     def testRandomRay(self):
         rays = RandomRays()  # We keep default value, we are not intersted in the construction of a specific object
         with self.assertRaises(NotImplementedError):
-            # This raises an exception, because with call a constant (i.e. constant(something))
+            # This works
             rays.randomRay()


### PR DESCRIPTION
It was throwing a constant, `NotImplemented`, which cannot be *called*, like we had: `raise NotImplemented("...")`. We now throw a proper `NotImplementedError`. 
Fixes #140.