### PR TITLE
RandomRays.rays is always None and RandomRays.__getitem__ always raises an exception

### DIFF
--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -22,6 +22,7 @@ or when analysing the resulting rays that reached a plane in ImagingPath,
 MatrixGroup or any tracing function. 
 """
 
+
 class Rays:
     def __init__(self, rays=None):
         if rays is None:
@@ -232,6 +233,7 @@ class Rays:
     # https://en.wikipedia.org/wiki/Xiaolin_Wu's_line_algorithm
     # and https://stackoverflow.com/questions/3122049/drawing-an-anti-aliased-line-with-thepython-imaging-library
 
+
 class UniformRays(Rays):
     def __init__(self, yMax=1.0, yMin=None, thetaMax=pi / 2, thetaMin=None, M=100, N=100):
         self.yMax = yMax
@@ -284,18 +286,18 @@ class RandomRays(Rays):
         self.thetaMin = thetaMin
         if thetaMin is None:
             self.thetaMin = -thetaMax
-        super(RandomRays, self).__init__(rays=None)
+        super(RandomRays, self).__init__(rays=None)  # Even with this, rays = []
 
     def __len__(self) -> int:
         return self.maxCount
 
     def __getitem__(self, item):
-        if self.rays is None:
+        if self.rays is None:  # This can never happen, rays = []
             raise NotImplementedError("You cannot access RandomRays")
         elif len(self.rays) < item:
             raise NotImplementedError("You cannot access RandomRays")
         else:
-            return self.rays[item]
+            return self.rays[item]  # This always lead to IndexError, rays is always []
 
     def __next__(self) -> Ray:
         if self.iteration >= self.maxCount:

--- a/raytracing/tests/testsRaysSubclasses.py
+++ b/raytracing/tests/testsRaysSubclasses.py
@@ -8,7 +8,14 @@ inf = float("+inf")
 class TestRandomRays(unittest.TestCase):
 
     def testRandomRay(self):
-        rays = RandomRays()  # We keep default value, we are not intersted in the construction of a specific object
+        rays = RandomRays()  # We keep default value, we are not interested in the construction of a specific object
         with self.assertRaises(NotImplementedError):
             # This works
             rays.randomRay()
+
+    def testGetItem(self):
+        rays = RandomRays(maxCount=10)
+        with self.assertRaises(NotImplementedError):
+            rays[11]  # Ok, 11 > 10
+
+        self.assertIsNotNone(rays[-1])  # This should be ok, according to the code, but it doesn't make sense


### PR DESCRIPTION
Since `RandomRays` creates `Ray` objects on demand, it doen't make sense to have `RandomRays.rays = []`. I think it should always be `None`.

Since `RandomRays` creates `Ray` objects on demand, it should never be accessed with `__getitem__`, because it doesn't contain any `Ray`. It is also a problem if we keep `rays = []`.
Fixes #145