### PR TITLE
We must specifically insert the directory that includes the working copy of raytracing

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,3 +1,4 @@
+import envexamples
 from raytracing import *
 
 path = ImagingPath()

--- a/examples/envexamples.py
+++ b/examples/envexamples.py
@@ -1,0 +1,11 @@
+import sys
+import os
+
+# append module root directory to sys.path
+sys.path.insert(0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.abspath(__file__)
+        )
+    )
+)

--- a/examples/exemple.py
+++ b/examples/exemple.py
@@ -1,6 +1,6 @@
+import envexamples
 import sys
 import os
-sys.path.insert(0, os.path.abspath('../'))
 
 from raytracing import *
 

--- a/examples/exemple.py
+++ b/examples/exemple.py
@@ -1,7 +1,4 @@
 import envexamples
-import sys
-import os
-
 from raytracing import *
 
 path = ImagingPath()

--- a/examples/illuminator.py
+++ b/examples/illuminator.py
@@ -1,6 +1,6 @@
+import envexamples
 import sys
 import os
-sys.path.insert(0, os.path.abspath('../'))
 
 from raytracing import *
 

--- a/examples/illuminator.py
+++ b/examples/illuminator.py
@@ -1,7 +1,4 @@
 import envexamples
-import sys
-import os
-
 from raytracing import *
 
 path = ImagingPath()

--- a/examples/invariant.py
+++ b/examples/invariant.py
@@ -1,7 +1,4 @@
 import envexamples
-import sys
-import os
-
 from raytracing import *
 
 path = ImagingPath()

--- a/examples/invariant.py
+++ b/examples/invariant.py
@@ -1,10 +1,6 @@
-# The raytracing module needs to be installed in your "site" path.
-# Type: python -m site --user-site
-# to see what this directory is (mine on macOS is /Users/dccote/.local/lib/python3.6/site-packages)
-
+import envexamples
 import sys
 import os
-sys.path.insert(0, os.path.abspath('../'))
 
 from raytracing import *
 

--- a/examples/multiProcessingTracing.py
+++ b/examples/multiProcessingTracing.py
@@ -1,4 +1,4 @@
-
+import envexamples
 import time
 import numpy
 

--- a/examples/testTracing.py
+++ b/examples/testTracing.py
@@ -1,3 +1,4 @@
+import envexamples
 from raytracing import *
 from numpy import *
 import matplotlib.pyplot as plt

--- a/examples/widefield.py
+++ b/examples/widefield.py
@@ -1,7 +1,4 @@
 import envexamples
-import os
-import sys
-
 from raytracing import *
 
 '''

--- a/examples/widefield.py
+++ b/examples/widefield.py
@@ -1,6 +1,6 @@
+import envexamples
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../'))
 
 from raytracing import *
 


### PR DESCRIPTION
The examples in the `examples` directory may be run before installing the `raytracing` package, or may be run by developers.  In this case, we want to import the current version of raytracing in the directory.  This adds everything  properly. All examples should start with the line:

```
import envexamples
```
which will add the containing directory to the path for imports.