### PR TITLE
Fixed eigenModes and laserModes

### DIFF
--- a/raytracing/laserpath.py
+++ b/raytracing/laserpath.py
@@ -54,10 +54,10 @@ class LaserPath(MatrixGroup):
 
         (q1, q2) = self.eigenModes()
         q = []
-        if q1.isFinite:
+        if q1 is not None and q1.isFinite:
             q.append(q1)
 
-        if q2.isFinite:
+        if q2 is not None and q2.isFinite:
             q.append(q2)
 
         return q

--- a/raytracing/laserpath.py
+++ b/raytracing/laserpath.py
@@ -1,6 +1,7 @@
 from .matrixgroup import *
 from .imagingpath import *
 
+
 class LaserPath(MatrixGroup):
     """LaserPath: the main class of the module for coherent
     laser beams: it is the combination of Matrix() or MatrixGroup()
@@ -17,6 +18,7 @@ class LaserPath(MatrixGroup):
     is set to indicate it, but it will propagate nevertheless
     and without diffraction due to that aperture.
     """
+
     def __init__(self, elements=None, label=""):
         self.inputBeam = None
         self.isResonator = False
@@ -33,11 +35,14 @@ class LaserPath(MatrixGroup):
         round trip: you will need to duplicate elements in reverse
         and append them manually. 
         """
+        if not self.hasPower:
+            return None, None
+
         b = self.D - self.A
-        sqrtDelta = cmath.sqrt(b*b + 4.0 *self.B *self.C)
-        
-        q1 = (- b + sqrtDelta)/(2.0*self.C)
-        q2 = (- b - sqrtDelta)/(2.0*self.C)
+        sqrtDelta = cmath.sqrt(b * b + 4.0 * self.B * self.C)
+
+        q1 = (- b + sqrtDelta) / (2.0 * self.C)
+        q2 = (- b - sqrtDelta) / (2.0 * self.C)
 
         return (GaussianBeam(q=q1), GaussianBeam(q=q2))
 
@@ -133,11 +138,10 @@ class LaserPath(MatrixGroup):
         for element in self.elements:
             if isinstance(element, Space):
                 for i in range(N):
-                    highResolution.append(Space(d=element.L/N, 
+                    highResolution.append(Space(d=element.L / N,
                                                 n=element.frontIndex))
             else:
                 highResolution.append(element)
-
 
         beamTrace = highResolution.trace(beam)
         (x, y) = self.rearrangeBeamTraceForPlotting(beamTrace)
@@ -166,11 +170,11 @@ class LaserPath(MatrixGroup):
             position = beam.z + relativePosition
             size = beam.waist
 
-            axes.arrow(position, size+arrowSize, 0, -arrowSize,
-                width=0.1, fc='g', ec='g',
-                head_length=arrowHeight, head_width=arrowWidth,
-                length_includes_head=True)
-            axes.arrow(position, -size-arrowSize, 0, arrowSize,
-                width=0.1, fc='g', ec='g',
-                head_length=arrowHeight, head_width=arrowWidth,
-                length_includes_head=True)
+            axes.arrow(position, size + arrowSize, 0, -arrowSize,
+                       width=0.1, fc='g', ec='g',
+                       head_length=arrowHeight, head_width=arrowWidth,
+                       length_includes_head=True)
+            axes.arrow(position, -size - arrowSize, 0, arrowSize,
+                       width=0.1, fc='g', ec='g',
+                       head_length=arrowHeight, head_width=arrowWidth,
+                       length_includes_head=True)

--- a/raytracing/tests/testsLaserPath.py
+++ b/raytracing/tests/testsLaserPath.py
@@ -1,0 +1,11 @@
+import unittest
+import envtest # modifies path
+from raytracing import *
+
+inf = float("+inf")
+
+class TestLaserPath(unittest.TestCase):
+
+    def testEigenModes(self):
+        lp = LaserPath([Space(10)])
+        self.assertIsNotNone(lp.eigenModes())

--- a/raytracing/tests/testsLaserPath.py
+++ b/raytracing/tests/testsLaserPath.py
@@ -19,7 +19,7 @@ class TestLaserPath(unittest.TestCase):
 
     def testLaserModes(self):
         lp = LaserPath()
-        lp.laserModes()
+        self.assertListEqual(lp.laserModes(), [])
 
 
 if __name__ == '__main__':

--- a/raytracing/tests/testsLaserPath.py
+++ b/raytracing/tests/testsLaserPath.py
@@ -14,6 +14,13 @@ class TestLaserPath(unittest.TestCase):
         lp = LaserPath()
         self.assertTupleEqual(lp.eigenModes(), (None, None))
 
+        lp = LaserPath([CurvedMirror(-10)])
+        self.assertNotEqual(lp.eigenModes(), (None, None))
+
+    def testLaserModes(self):
+        lp = LaserPath()
+        lp.laserModes()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/raytracing/tests/testsLaserPath.py
+++ b/raytracing/tests/testsLaserPath.py
@@ -1,11 +1,19 @@
 import unittest
-import envtest # modifies path
+import envtest  # modifies path
 from raytracing import *
 
 inf = float("+inf")
+
 
 class TestLaserPath(unittest.TestCase):
 
     def testEigenModes(self):
         lp = LaserPath([Space(10)])
-        self.assertIsNotNone(lp.eigenModes())
+        self.assertTupleEqual(lp.eigenModes(), (None, None))
+
+        lp = LaserPath()
+        self.assertTupleEqual(lp.eigenModes(), (None, None))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When `LaserPath` has `C == 0`, we have a division by 0 in `eigenModes` and this problem impacts `laserModes` because it relies on `eigenModes`. I propose we return `(None, None)` in `eigenModes` when `C == 0` and an empty list in `laserModes`.

Fixes #179 