### PR TITLE
Tests for LaserPath

### DIFF
--- a/raytracing/laserpath.py
+++ b/raytracing/laserpath.py
@@ -62,7 +62,7 @@ class LaserPath(MatrixGroup):
 
         return q
 
-    def display(self, inputBeam=None, inputBeams=None, comments=None):
+    def display(self, inputBeam=None, inputBeams=None, comments=None):  # pragma: no cover
         """ Display the optical system and trace the laser beam. 
         If comments are included they will be displayed on a
         graph in the bottom half of the plot.
@@ -71,7 +71,7 @@ class LaserPath(MatrixGroup):
 
         if self.isResonator:
             beams = self.laserModes()
-            if len(self.label) == "":
+            if self.label == "":
                 self.label = "Laser modes as calculated"
         elif inputBeam is not None:
             beams = [inputBeam]
@@ -80,7 +80,7 @@ class LaserPath(MatrixGroup):
         else:
             beams = [self.inputBeam]
 
-        if len(self.label) == "":
+        if self.label == "":
             self.label = "User-specified gaussian beams"
 
         if comments is not None:
@@ -95,7 +95,7 @@ class LaserPath(MatrixGroup):
 
         self._showPlot()
 
-    def createBeamTracePlot(self, axes, beams):
+    def createBeamTracePlot(self, axes, beams):  # pragma: no cover
         """ Create a matplotlib plot to draw the laser beam and the elements.
         """
 
@@ -122,7 +122,7 @@ class LaserPath(MatrixGroup):
             y.append(ray.w)
         return (x, y)
 
-    def drawBeamTrace(self, axes, beam):
+    def drawBeamTrace(self, axes, beam):  # pragma: no cover
         """ Draw beam trace corresponding to input beam 
         Because the laser beam diffracts through space, we cannot
         simply propagate the beam over large distances and trace it
@@ -148,7 +148,7 @@ class LaserPath(MatrixGroup):
         axes.plot(x, y, 'r', linewidth=1)
         axes.plot(x, [-v for v in y], 'r', linewidth=1)
 
-    def drawWaists(self, axes, beam):
+    def drawWaists(self, axes, beam):  # pragma: no cover
         """ Draws the expected waist (i.e. the focal spot or the spot where the
         size is minimum) for all positions of the beam. This will show "waists" that
         are virtual if there is an additional lens between the beam and the expceted

--- a/raytracing/tests/testsLaserPath.py
+++ b/raytracing/tests/testsLaserPath.py
@@ -7,7 +7,6 @@ inf = float("+inf")
 
 class TestLaserPath(unittest.TestCase):
 
-
     def testLaserPathNoElements(self):
         lasPath = LaserPath()
         self.assertIsNone(lasPath.inputBeam)
@@ -29,7 +28,6 @@ class TestLaserPath(unittest.TestCase):
         with self.assertRaises(TypeError):
             LaserPath(elements)
 
-    @unittest.skip("Fixed soon")
     def testEigenModesNoPower(self):
         lp = LaserPath([Space(10)])
         self.assertTupleEqual(lp.eigenModes(), (None, None))
@@ -47,7 +45,6 @@ class TestLaserPath(unittest.TestCase):
         self.assertEqual(beam1.q, beam2.q)
         self.assertEqual(beam1.q, 0)
 
-    @unittest.skip("Fixed soon")
     def testLaserModesNoPower(self):
         lp = LaserPath([Space(10)])
         self.assertListEqual(lp.laserModes(), [])
@@ -60,9 +57,25 @@ class TestLaserPath(unittest.TestCase):
         self.assertEqual(beam.q.real, -5)
         self.assertAlmostEqual(beam.q.imag, 5 * 3 ** 0.5)
 
-        lp = Laser
+        elements = [Space(1, 1.33), DielectricInterface(1.33, 1, 1), ThickLens(1.33, -10, -5, -20)]
+        lp = LaserPath(elements)
+        laserModes = lp.laserModes()
+        self.assertEqual(len(laserModes), 1)
+        beam = laserModes[0]
+        self.assertAlmostEqual(beam.q.real, -5.90770102)
+        self.assertAlmostEqual(beam.q.imag, 1.52036515)
 
+        lp = LaserPath([Space(10), CurvedMirror(5)])
+        self.assertListEqual(lp.laserModes(), [])
+        lp = LaserPath()
+        self.assertListEqual(lp.laserModes(), [])
 
+    def testRearrangeBeamTraceForPlotting(self):
+        x = [x for x in range(1, 6)]
+        y = [y for y in range(1, 6)]
+        rayList = [GaussianBeam(w=x_, z=y_) for (x_, y_) in zip(x, y)]
+        lp = LaserPath()
+        self.assertTupleEqual(lp.rearrangeBeamTraceForPlotting(rayList), (x, y))
 
 if __name__ == '__main__':
     unittest.main()

--- a/raytracing/tests/testsLaserPath.py
+++ b/raytracing/tests/testsLaserPath.py
@@ -1,0 +1,67 @@
+import unittest
+import envtest  # modifies path
+from raytracing import *
+
+inf = float("+inf")
+
+
+class TestLaserPath(unittest.TestCase):
+
+    def testLaserPathNoElements(self):
+        lasPath = LaserPath()
+        self.assertIsNone(lasPath.inputBeam)
+        self.assertFalse(lasPath.isResonator)
+        self.assertTrue(lasPath.showElementLabels)
+        self.assertTrue(lasPath.showPointsOfInterest)
+        self.assertTrue(lasPath.showPointsOfInterestLabels)
+        self.assertTrue(lasPath.showPlanesAcrossPointsOfInterest)
+        self.assertListEqual(lasPath.elements, [])
+
+    def testLaserPath(self):
+        elements = [Space(5), Lens(5), Space(20), Lens(15), Space(15)]
+        lp = LaserPath(elements, "Laser Path")
+        self.assertListEqual(lp.elements, elements)
+        self.assertEqual(lp.label, "Laser Path")
+
+    def testLaserPathIncorrectElements(self):
+        elements = [Ray(), Lens(10)]
+        with self.assertRaises(TypeError):
+            LaserPath(elements)
+
+    @unittest.skip("Fixed soon")
+    def testEigenModesNoPower(self):
+        lp = LaserPath([Space(10)])
+        self.assertTupleEqual(lp.eigenModes(), (None, None))
+
+    def testEigenModes(self):
+        lp = LaserPath([Space(10), Lens(10)])
+        beam1, beam2 = lp.eigenModes()
+        self.assertEqual(beam1.q.real, -5)
+        self.assertEqual(beam2.q.real, -5)
+        self.assertAlmostEqual(beam1.q.imag, -5 * 3 ** 0.5)
+        self.assertAlmostEqual(beam2.q.imag, 5 * 3 ** 0.5)
+
+        lp = LaserPath([Lens(10)])
+        beam1, beam2 = lp.eigenModes()
+        self.assertEqual(beam1.q, beam2.q)
+        self.assertEqual(beam1.q, 0)
+
+    @unittest.skip("Fixed soon")
+    def testLaserModesNoPower(self):
+        lp = LaserPath([Space(10)])
+        self.assertListEqual(lp.laserModes(), [])
+
+    def testLaserModes(self):
+        lp = LaserPath([Space(10), Lens(10)])
+        laserModes = lp.laserModes()
+        self.assertEqual(len(laserModes), 1)
+        beam = laserModes[0]
+        self.assertEqual(beam.q.real, -5)
+        self.assertAlmostEqual(beam.q.imag, 5 * 3 ** 0.5)
+
+        lp = Laser
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
100% coverage for non display methods (no tests for them). I also changed a little part of `LaserPath`:
 - In `display`, there was `if len(self.label) == ""`, but `len()` returns an integer. I replaced it by `if self.label == ""`. `if len(self.label) == 0` is also another option)

Fixes #108 