### PR TITLE
Proposition (can somewhat fix problem with ImagingPath and LaserPath methods in MatrixGroup)

### DIFF
--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -10,6 +10,7 @@ class MatrixGroup(Matrix):
     """
 
     def __init__(self, elements=None, label=""):
+        self.iteration = 0
         super(MatrixGroup, self).__init__(1, 0, 0, 1, label=label)
 
         self.elements = []
@@ -36,7 +37,7 @@ class MatrixGroup(Matrix):
         if len(self.elements) != 0:
             lastElement = self.elements[-1]
             if lastElement.backIndex != matrix.frontIndex:
-                if isinstance(matrix, Space): # For Space(), we fix it
+                if isinstance(matrix, Space):  # For Space(), we fix it
                     msg = "Fixing mismatched indices between last element and appended Space(). Use Space(d=someDistance, n=someIndex)."
                     warnings.warn(msg, UserWarning)
                     matrix.frontIndex = lastElement.backIndex
@@ -54,12 +55,6 @@ class MatrixGroup(Matrix):
         self.L = transferMatrix.L
         self.frontVertex = transferMatrix.frontVertex
         self.backVertex = transferMatrix.backVertex
-
-    def ImagingPath(self):
-        return ImagingPath(elements=self.elements, label=self.label)
-
-    def LaserPath(self):
-        return LaserPath(elements=self.elements, label=self.label)
 
     def transferMatrix(self, upTo=float('+Inf')):
         """ The transfer matrix between front edge and distance=upTo
@@ -227,3 +222,16 @@ class MatrixGroup(Matrix):
             axes.annotate(label, xy=(z, 0.0), xytext=(z, -halfHeight * 0.5),
                           xycoords='data', fontsize=12,
                           ha='center', va='bottom')
+
+    def __iter__(self):
+        self.iteration = 0
+        return self
+
+    def __next__(self):
+        if self.elements is None:
+            raise StopIteration
+        if self.iteration < len(self.elements):
+            element = self.elements[self.iteration]
+            self.iteration += 1
+            return element
+        raise StopIteration

--- a/raytracing/tests/testsMatrixGroup.py
+++ b/raytracing/tests/testsMatrixGroup.py
@@ -319,6 +319,11 @@ class TestMatrixGroup(unittest.TestCase):
         self.assertEqual(mg.D, supposedMatrix.D)
         self.assertEqual(mg.L, supposedMatrix.L)
 
+    def testInitWithAnotherMatrixGroup(self):
+        mg = MatrixGroup([Lens(5)])
+        mg2 = MatrixGroup(mg)
+        self.assertListEqual(mg.elements, mg2.elements)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I propose that `MatrixGroup` is iterable. That way, we can accept an instance of `MatrixGroup` as argument in `__init__`. For example:
```
mg = MatrixGroup([Lens(10)])
mg2 = MatrixGroup(mg) 
```
is now possible, because `MatrixGroup` can be iterated over.

I can see this as (somewhat) a fix for `ImagingPath` and `LaserPath` methods present in `MatrixGroup` (issue #90):
- We can give an already existing `MatrixGroup` to `LaserPath` and `ImagingPath`, because `MatrixGroup` is iterable. A `LaserPath` can also be built upon an already existing `LaserPath`, even a `ImagingPath`.

Fixes #90