### PR TITLE
Fix chief ray with no aperture stop (ImaginPath)

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -153,6 +153,9 @@ class ImagingPath(MatrixGroup):
         a proper chief ray. So the function will return None.
         """
         (stopPosition, stopDiameter) = self.apertureStop()
+        if stopPosition is None:
+            return None
+
         transferMatrixToApertureStop = self.transferMatrix(upTo=stopPosition)
         A = transferMatrixToApertureStop.A
         B = transferMatrixToApertureStop.B

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -151,6 +151,7 @@ class ImagingPath(MatrixGroup):
         If the element B in the transfer matrix for the imaging path
         is zero, there is no value for the height and angle that makes
         a proper chief ray. So the function will return None.
+        If there is no aperture stop, there is no chief ray either. None is also returned.
         """
         (stopPosition, stopDiameter) = self.apertureStop()
         if stopPosition is None:

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -59,6 +59,7 @@ class TestImagingPath(unittest.TestCase):
     def testChiefRayNoApertureStop(self):
         path = ImagingPath(System2f(10))
         chiefRay = path.chiefRay()
+        self.assertIsNone(chiefRay)
 
 if __name__ == '__main__':
     unittest.main()

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -56,6 +56,9 @@ class TestImagingPath(unittest.TestCase):
         path = ImagingPath(elements)
         self.assertIsNotNone(path.entrancePupil())
 
+    def testChiefRayNoApertureStop(self):
+        path = ImagingPath(System2f(10))
+        chiefRay = path.chiefRay()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When an `ImagingPath` has no aperture stop, an exception is raised when we try to get the chief ray of the system. The problem is that `stopPosition` (the position of the aperture stop) is `None` and we try comparisons and computations with it. This pull request adds a check to `stopPosition` and if it is `None`, we return `None` because there is no proper chief ray. I also updated the documentation to specify that no aperture stop means no chief ray.

Fixes #191 