### PR TITLE
ImageSize of ImagingPath returns inf when there is no forward conjugate

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -585,6 +585,9 @@ class ImagingPath(MatrixGroup):
         """
         fieldOfView = self.fieldOfView()
         (distance, conjugateMatrix) = self.forwardConjugate()
+        if conjugateMatrix is None:
+            return float("+inf")
+
         magnification = conjugateMatrix.A
         return abs(fieldOfView * magnification)
 

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -61,5 +61,10 @@ class TestImagingPath(unittest.TestCase):
         chiefRay = path.chiefRay()
         self.assertIsNone(chiefRay)
 
+    def testImageSizeDIs0(self):
+        path = ImagingPath(System2f(f=10, diameter=10))
+        path.append(Aperture(20))
+        self.assertEqual(path.imageSize(), inf)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There was a problem with `imageSize` when the current `ImagingPath` has `D == 0`, it raised an `AttributeError` because the forward conjugate matrix doesn't exist (it is `None`). The code now checks `if conjugateMatrix is None` then returns `float("+inf")` if it is the case.

Fixes #188