### PR TITLE
Fix chiefRay when B is close to 0 (but not 0)

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -161,7 +161,7 @@ class ImagingPath(MatrixGroup):
         A = transferMatrixToApertureStop.A
         B = transferMatrixToApertureStop.B
 
-        if B == 0:
+        if transferMatrixToApertureStop.isImaging:
             return None
 
         if y is None:

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -161,7 +161,7 @@ class ImagingPath(MatrixGroup):
         A = transferMatrixToApertureStop.A
         B = transferMatrixToApertureStop.B
 
-        if B == 0:
+        if self.isImaging:
             return None
 
         if y is None:

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -161,7 +161,7 @@ class ImagingPath(MatrixGroup):
         A = transferMatrixToApertureStop.A
         B = transferMatrixToApertureStop.B
 
-        if self.isImaging:
+        if abs(B) <= Matrix.__epsilon__:
             return None
 
         if y is None:

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -161,7 +161,7 @@ class ImagingPath(MatrixGroup):
         A = transferMatrixToApertureStop.A
         B = transferMatrixToApertureStop.B
 
-        if abs(B) <= Matrix.__epsilon__:
+        if B == 0:
             return None
 
         if y is None:

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -61,5 +61,9 @@ class TestImagingPath(unittest.TestCase):
         chiefRay = path.chiefRay()
         self.assertIsNone(chiefRay)
 
+    def testChiefRayBIs0(self):
+        path = ImagingPath(System4f(10, 10, 10, 10))
+        self.assertIsNone(path.chiefRay())
+
 if __name__ == '__main__':
     unittest.main()

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -62,7 +62,9 @@ class TestImagingPath(unittest.TestCase):
         self.assertIsNone(chiefRay)
 
     def testChiefRayBIs0(self):
-        path = ImagingPath(System4f(10, 10, 10, 10))
+        path = ImagingPath(System4f(pi*2, pi*1.25))
+        path.append(System4f(pi, pi/1.2))
+        path.append(Aperture(10))
         self.assertIsNone(path.chiefRay())
 
 if __name__ == '__main__':


### PR DESCRIPTION
When we want the chief ray of a system that has `B == 0`, we return `None`. But in some cases, `B !=0` but still very small (like 7x10^-16). I changed `B == 0` to `transferMatrixToApertureStop.isImaging`, that way we consider if `B` is smaller than an arbitrary `__epsilon__` value.

Fixes #197 

Note: Some commits are irrelevant because I didn't quite understand the problem at the beginning