### PR TITLE
ChiefRay raises exception when no y and infinite field of view

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -166,6 +166,8 @@ class ImagingPath(MatrixGroup):
 
         if y is None:
             y = self.fieldOfView()
+            if abs(y) == float("+inf"):
+                raise ValueError("Must provide y when the filed of view is infinite")
 
         return Ray(y=y, theta=-A * y / B)
 

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -61,5 +61,12 @@ class TestImagingPath(unittest.TestCase):
         chiefRay = path.chiefRay()
         self.assertIsNone(chiefRay)
 
+    def testChiefRayInfiniteFieldOfViewNoY(self):
+        path = ImagingPath()
+        path.append(System2f(10, path.maxHeight + 1))
+        with self.assertRaises(ValueError):
+            path.chiefRay()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When we create an `ImagingPath` with an infinite field of view and we don't specify `y`, we get a ray with y = inf and theta = -inf. Now, if the field of view is infinite and we don't give a specific `y`, an exception is raised.

Fixes #193