### PR TITLE
Fix marginal rays when no aperture stop

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -188,7 +188,6 @@ class ImagingPath(MatrixGroup):
         """
         return self.chiefRay(y=None)
 
-
     def marginalRays(self, y=0):
         """This function calculates the marginal rays for a height y at object.
         The marginal rays for height y are the rays that hit the upper and lower
@@ -256,11 +255,14 @@ class ImagingPath(MatrixGroup):
 
         """
         (stopPosition, stopDiameter) = self.apertureStop()
+        if stopPosition is None:
+            return None  # No aperture stop -> no marginal rays
+
         transferMatrixToApertureStop = self.transferMatrix(upTo=stopPosition)
         A = transferMatrixToApertureStop.A
         B = transferMatrixToApertureStop.B
 
-        thetaUp  = (stopDiameter / 2.0 - A * y) / B
+        thetaUp = (stopDiameter / 2.0 - A * y) / B
         thetaDown = (-stopDiameter / 2.0 - A * y) / B
 
         if thetaDown > thetaUp:
@@ -681,10 +683,10 @@ class ImagingPath(MatrixGroup):
         display range : 7
 
         """
-        
+
         displayRange = self.largestDiameter
-        if displayRange == float('+Inf') or displayRange <= 2*self.objectHeight:
-            displayRange = 2*self.objectHeight
+        if displayRange == float('+Inf') or displayRange <= 2 * self.objectHeight:
+            displayRange = 2 * self.objectHeight
 
         conjugates = self.intermediateConjugates()
         if len(conjugates) != 0:
@@ -976,7 +978,7 @@ class ImagingPath(MatrixGroup):
         arrowHeadHeight = self.objectHeight * 0.1
 
         heightFactor = self.objectHeight / yScaling
-        arrowHeadWidth = xScaling * 0.01 * (heightFactor/0.2) ** (3/4)
+        arrowHeadWidth = xScaling * 0.01 * (heightFactor / 0.2) ** (3 / 4)
 
         axes.arrow(
             self.objectPosition,
@@ -1009,7 +1011,7 @@ class ImagingPath(MatrixGroup):
             arrowHeadHeight = arrowHeight * 0.1
 
             heightFactor = arrowHeight / yScaling
-            arrowHeadWidth = xScaling * 0.01 * (heightFactor/0.2) ** (3/4)
+            arrowHeadWidth = xScaling * 0.01 * (heightFactor / 0.2) ** (3 / 4)
 
             axes.arrow(
                 imagePosition,
@@ -1080,7 +1082,7 @@ class ImagingPath(MatrixGroup):
             center = z + pupilPosition
             (xScaling, yScaling) = self.axesToDataScale(axes)
             heightFactor = halfHeight * 2 / yScaling
-            width = xScaling * 0.01 / 2 * (heightFactor/0.2) ** (3/4)
+            width = xScaling * 0.01 / 2 * (heightFactor / 0.2) ** (3 / 4)
 
             axes.add_patch(patches.Polygon(
                 [[center - width, halfHeight],

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -61,5 +61,9 @@ class TestImagingPath(unittest.TestCase):
         chiefRay = path.chiefRay()
         self.assertIsNone(chiefRay)
 
+    def testMarginalRaysNoApertureStop(self):
+        path = ImagingPath(System4f(10, 10))
+        self.assertIsNone(path.marginalRays())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When there is no aperture stop in an `ImagingPath`, there shouldn't be any marginal rays. So, we now return `None` in that case.

Fixes #201 