### PR TITLE
Fix margial rays when B is 0

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -260,6 +260,9 @@ class ImagingPath(MatrixGroup):
         A = transferMatrixToApertureStop.A
         B = transferMatrixToApertureStop.B
 
+        if transferMatrixToApertureStop.isImaging:
+            return None
+
         thetaUp  = (stopDiameter / 2.0 - A * y) / B
         thetaDown = (-stopDiameter / 2.0 - A * y) / B
 

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -64,7 +64,7 @@ class TestImagingPath(unittest.TestCase):
     def testMarginalRaysIsImaging(self):
         path = ImagingPath(System4f(10, 10))
         path.append(Aperture(10))
-        self.assertIsNotNone(path.marginalRays())
+        self.assertIsNone(path.marginalRays())
 
 if __name__ == '__main__':
     unittest.main()

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -61,5 +61,10 @@ class TestImagingPath(unittest.TestCase):
         chiefRay = path.chiefRay()
         self.assertIsNone(chiefRay)
 
+    def testMarginalRaysIsImaging(self):
+        path = ImagingPath(System4f(10, 10))
+        path.append(Aperture(10))
+        self.assertIsNotNone(path.marginalRays())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When a transfer matrix to the aperture stop has `B == 0`, we have a division by 0 when we try to compute the ±theta of the marginal rays. Now, we return `None` in that case.

Fixes #203 