### PR TITLE
Make some design parameters accessible to the user

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -939,7 +939,7 @@ class ImagingPath(MatrixGroup):
             binSize = 2.0 * halfHeight / (len(color) - 1)
             colorIndex = int(
                 (rayInitialHeight - (-halfHeight - binSize / 2)) / binSize)
-            axes.plot(x, y, color[colorIndex], linewidth=linewidth, label='ray')
+            axes.plot(x, y, color=color[colorIndex], linewidth=linewidth, label='ray')
 
     def rearrangeRayTraceForPlotting(self, rayList,
                                      removeBlockedRaysCompletely=True):

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -87,6 +87,7 @@ class ImagingPath(MatrixGroup):
         self.fanAngle = 0.1  # full fan angle for rays
         self.fanNumber = 9  # number of rays in fan
         self.rayNumber = 3  # number of points on object
+        self.design = {'rayColors': ['b', 'r', 'g']}  # design variables accessible to the user for customization
 
         # Constants when calculating field stop
         self.precision = 0.001
@@ -906,7 +907,7 @@ class ImagingPath(MatrixGroup):
 
         """
 
-        color = ['b', 'r', 'g']
+        color = self.design['rayColors']
 
         if onlyChiefAndMarginalRays:
             halfHeight = self._objectHeight / 2.0


### PR DESCRIPTION
I'm not sure it's optimal, but since we want it to be scalable, I thought we could keep a dictionary of design parameters for ImagingPath. 

For now this enables the user to change the ray colors by providing a new list of colors like so:

```
path = ImagingPath()
path.design['rayColors'] = ['b', 'b', 'b']
# or 
path.design['rayColors'] = [(0.4, 0.9, 1), (0.4, 0.7, 1), (0.4, 0.5, 1)]
```
![image](https://user-images.githubusercontent.com/29587649/83454180-ce4d2c80-a429-11ea-84fb-781962c1e00b.png)
