### PR TITLE
GaussianBeam: check inputs in init

### DIFF
--- a/raytracing/gaussianbeam.py
+++ b/raytracing/gaussianbeam.py
@@ -12,14 +12,17 @@ class GaussianBeam(object):
 
     def __init__(self, q:complex=None, w:float=None, R:float=float("+Inf"), n:float=1.0, wavelength=632.8e-6, z=0):
         # Gaussian beam matrix formalism
-        if q is not None and w is not None:
-            raise ValueError("Please only specify one of the two: 'q' or 'w'. Choosing q or w is ambiguous.")
+
         if q is not None:
             self.q = q
-        elif w is not None:
+        if w is not None:
             self.q = 1/( 1.0/R - complex(0,1)*wavelength/n/(math.pi*w*w))
-        else:
-            raise ValueError("Please specify 'q' or 'w'.") 
+        if q is None and w is None:
+            raise ValueError("Please specify 'q' or 'w'.")
+
+        if q is not None and w is not None:
+            if not cmath.isclose(a=self.q, b=q, abs_tol=0.1):
+                raise ValueError("Mismatch between the given q and the computed q (10% tolerance).")
 
         self.wavelength = wavelength
         

--- a/raytracing/gaussianbeam.py
+++ b/raytracing/gaussianbeam.py
@@ -12,12 +12,14 @@ class GaussianBeam(object):
 
     def __init__(self, q:complex=None, w:float=None, R:float=float("+Inf"), n:float=1.0, wavelength=632.8e-6, z=0):
         # Gaussian beam matrix formalism
+        if q is not None and w is not None:
+            raise ValueError("Please only specify one of the two: 'q' or 'w'. Choosing q or w is ambiguous.")
         if q is not None:
             self.q = q
         elif w is not None:
             self.q = 1/( 1.0/R - complex(0,1)*wavelength/n/(math.pi*w*w))
         else:
-            self.q = None 
+            raise ValueError("Please specify 'q' or 'w'.") 
 
         self.wavelength = wavelength
         

--- a/raytracing/tests/testsGaussian.py
+++ b/raytracing/tests/testsGaussian.py
@@ -6,7 +6,6 @@ inf = float("+inf")
 
 class TestBeam(unittest.TestCase):
     def testBeam(self):
-        beam = GaussianBeam()
         beam = GaussianBeam(w=1)
         self.assertEqual(beam.w, 1)
         self.assertEqual(beam.R, float("+Inf"))
@@ -19,10 +18,13 @@ class TestBeam(unittest.TestCase):
 
     def testInvalidParameters(self):
         with self.assertRaises(Exception) as context:
-	        beam = GaussianBeam(w=1,R=0)
+            beam = GaussianBeam()
+
+        with self.assertRaises(Exception) as context:
+            beam = GaussianBeam(w=1,R=0)
 
     def testMultiplicationBeam(self):
-    	# No default parameters
+        # No default parameters
         beamIn = GaussianBeam(w=0.01, R=1, n=1.5, wavelength=0.400e-3)
         beamOut = Space(d=0,n=1.5)*beamIn
         self.assertEqual(beamOut.q, beamIn.q)


### PR DESCRIPTION
When we create a `GaussianBeam`, we should check if w or q are both `None`. If it is the case, we should not create a `GaussianBeam` because it doesn't make any physical sense.

If both are not `None`, we should create a `GaussianBeam`, but only if q computed with w fits (within a certain %) with the given q. That way, we ensure that the creation of a `GaussianBeam` is coherent if a user inputs both w and q; we make sure there is no mismatch between them.

Fixes #219 