### PR TITLE
Fix Matrix's hasPower

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -846,7 +846,8 @@ class Matrix(object):
 
     @property
     def hasPower(self):
-        """ If True, then there is a non-null focal length because C!=0
+        """ If True, then there is a non-null focal length because C!=0. We compare to an epsilon value, because
+        computational errors can occur and lead to C being very small, but not 0.
 
         Examples
         --------
@@ -861,7 +862,7 @@ class Matrix(object):
         >>> print('hasPower:' , M2.hasPower)
         hasPower: False
         """
-        return self.C != 0
+        return abs(self.C) < Matrix.__epsilon__
 
     def pointsOfInterest(self, z):
         """ Any points of interest for this matrix (focal points,

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -862,7 +862,7 @@ class Matrix(object):
         >>> print('hasPower:' , M2.hasPower)
         hasPower: False
         """
-        return abs(self.C) < Matrix.__epsilon__
+        return abs(self.C) > Matrix.__epsilon__
 
     def pointsOfInterest(self, z):
         """ Any points of interest for this matrix (focal points,

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -344,6 +344,15 @@ class TestMatrix(unittest.TestCase):
         m2 = Matrix(A=1, B=1, C=3, D=4)
         self.assertFalse(m2.isImaging)
 
+    def testHasNoPower(self):
+        f1 = 1.0000000000000017
+        f2 = 2.05 * f1
+
+        # This simulates a 4f system (since we test Matrix, we should only use basic matrices)
+        m = Matrix(1, f1, 0, 1) * Matrix(1, 0, -1 / f1, 1) * Matrix(1, f1, 0, 1) * Matrix(1, f2, 0, 1)
+        m = m * Matrix(1, 0, -1 / f2, 1) * Matrix(1, f1, 0, 1)
+        self.assertFalse(m.hasPower)
+
     def testEffectiveFocalLengthsHasPower(self):
         m = Matrix(1, 2, 3, 4)
         focalLengths = (-1 / 3, -1 / 3)


### PR DESCRIPTION
`Matrix`'s `hasPower` was directly comparing `self.C != 0`. In some cases, computational errors lead to C~0, but since we check if it is different, we don't get the right answer. I propose we compare `abs(self.C) > Matrix.__epsilon__`, that way small values that can be caused by using floats and inexact calculations don't lead to a wrong output.

Fixes #222 