### PR TITLE
MatrixGroup: save setup

### DIFF
--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -236,7 +236,16 @@ class MatrixGroup(Matrix):
             return element
         raise StopIteration
 
-    def saveElements(self, filePath: str):
+    def save(self, filePath:str):
+
+        """ A MatrixGroup can be saved using this function and loaded with `load()`
+
+        Parameters
+        ----------
+        filePath : str or PathLike or file-like object
+            A path, or a Python file-like object, or possibly some backend-dependent object.
+            Must be provided in OS-dependent format.
+        """
         with open(filePath, "wb") as outfile:
             pickle.Pickler(outfile).dump(self.elements)
 
@@ -262,7 +271,18 @@ class MatrixGroup(Matrix):
                     # Not possible, yet: sometimes we get here
                     time.sleep(0.1)
 
-    def loadElements(self, filePath: str, append: bool = False):
+    def load(self, filePath, append=False):
+        """ A MatrixGroup saved with `save()` can be loaded using this function.
+
+        Parameters
+        ----------
+        filePath : str or PathLike or file-like object
+            A path, or a Python file-like object, or possibly some backend-dependent object.
+            Must be provided in OS-dependent format.
+        append : bool
+            If True, the loaded elements will be appended to the current list of elements.
+        """
+
         with open(filePath, 'rb') as infile:
             loadedMatrices = pickle.Unpickler(infile).load()
             if not isinstance(loadedMatrices, collections.Iterable):

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -270,6 +270,9 @@ class MatrixGroup(Matrix):
             if not all([isinstance(matrix, Matrix) for matrix in loadedMatrices]):
                 raise IOError(f"{filePath} must contain only Matrix objects.")
             if append and self.elements is not None:
-                self.elements.extend(loadedMatrices)
+                for element in loadedMatrices:
+                    self.append(element)
             else:
-                self.elements = loadedMatrices
+                self.elements = []
+                for element in loadedMatrices:
+                    self.append(element)

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -235,3 +235,41 @@ class MatrixGroup(Matrix):
             self.iteration += 1
             return element
         raise StopIteration
+
+    def saveElements(self, filePath: str):
+        with open(filePath, "wb") as outfile:
+            pickle.Pickler(outfile).dump(self.elements)
+
+            # We save the data to disk using a module called Pickler
+            # Some asynchronous magic is happening here with Pickle
+            # and sometimes, access to files is wonky, especially
+            # when the files are very large.
+            # Make sure file exists
+            while not os.path.exists(filePath):
+                time.sleep(0.1)
+
+            oldSize = None
+            # Make sure file is not still being written to
+            while True:
+                try:
+                    currentSize = os.path.getsize(filePath)
+                    if currentSize == oldSize:
+                        break
+
+                    time.sleep(1)
+                    oldSize = currentSize
+                except:
+                    # Not possible, yet: sometimes we get here
+                    time.sleep(0.1)
+
+    def loadElements(self, filePath: str, append: bool = False):
+        with open(filePath, 'rb') as infile:
+            loadedMatrices = pickle.Unpickler(infile).load()
+            if not isinstance(loadedMatrices, collections.Iterable):
+                raise IOError(f"{filePath} does not contain an iterable of Matrix objects.")
+            if not all([isinstance(matrix, Matrix) for matrix in loadedMatrices]):
+                raise IOError(f"{filePath} must contain only Matrix objects.")
+            if append and self.elements is not None:
+                self.elements.extend(loadedMatrices)
+            else:
+                self.elements = loadedMatrices

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -399,7 +399,7 @@ class Rays:
         ----------
         filePath : str or PathLike or file-like object
             A path, or a Python file-like object, or possibly some backend-dependent object.
-            (Is the format important? what is the default format?)
+            Must be provided in OS-dependent format.
         append : bool
             If True, the loaded rays will be appended to the current list of rays.
         """
@@ -423,7 +423,7 @@ class Rays:
         ----------
         filePath : str or PathLike or file-like object
             A path, or a Python file-like object, or possibly some backend-dependent object.
-            (Is the form at important? what is the default format?)
+            Must be provided in OS-dependent format.
         """
 
         with open(filePath, 'wb') as outfile:

--- a/raytracing/tests/testsMatrixGroup.py
+++ b/raytracing/tests/testsMatrixGroup.py
@@ -350,7 +350,7 @@ class TestSaveAndLoadMatrixGroup(unittest.TestCase):
 
     def assertSaveNotFailed(self, matrixGroup: MatrixGroup, name: str):
         try:
-            matrixGroup.saveElements(name)
+            matrixGroup.save(name)
         except Exception as exception:
             self.fail(f"An exception was raised:\n{exception}")
 
@@ -358,7 +358,7 @@ class TestSaveAndLoadMatrixGroup(unittest.TestCase):
         if name is None:
             name = self.fileName
         try:
-            matrixGroup.loadElements(name, append)
+            matrixGroup.load(name, append)
         except Exception as exception:
             self.fail(f"An exception was raised:\n{exception}")
 
@@ -405,7 +405,7 @@ class TestSaveAndLoadMatrixGroup(unittest.TestCase):
         fname = r"this\file\does\not\exist.pkl"
         mg = MatrixGroup()
         with self.assertRaises(FileNotFoundError):
-            mg.loadElements(fname)
+            mg.load(fname)
 
     def testLoadInEmptyMatrixGroup(self):
         mg = MatrixGroup()
@@ -432,7 +432,7 @@ class TestSaveAndLoadMatrixGroup(unittest.TestCase):
 
         try:
             with self.assertRaises(IOError):
-                MatrixGroup().loadElements(fname)
+                MatrixGroup().load(fname)
         except AssertionError as exception:
             self.fail(str(exception))
 
@@ -444,7 +444,7 @@ class TestSaveAndLoadMatrixGroup(unittest.TestCase):
         time.sleep(0.5)
         try:
             with self.assertRaises(IOError):
-                MatrixGroup().loadElements(fname)
+                MatrixGroup().load(fname)
         except AssertionError as exception:
             self.fail(str(exception))
 

--- a/raytracing/tests/testsMatrixGroup.py
+++ b/raytracing/tests/testsMatrixGroup.py
@@ -392,7 +392,7 @@ class TestSaveAndLoadMatrixGroup(unittest.TestCase):
         mg = MatrixGroup([Space(20), ThickLens(1.22, 10, 10, 10)])
         self.assertSaveNotFailed(mg, self.fileName)
 
-    @unittest.skipIf(not testSaveHugeFile, "Don't test saving a lot of elements")
+    @unittest.skipIf(not testSaveHugeFile, "Don't test saving a lot of matrices")
     def testSaveHugeFile(self):
         fname = os.path.join(TestSaveAndLoadMatrixGroup.dirName, "hugeFile.pkl")
         spaces = [Space(10) for _ in range(500)]
@@ -456,7 +456,7 @@ class TestSaveAndLoadMatrixGroup(unittest.TestCase):
         self.assertLoadNotFailed(mg2, fname)
         self.assertLoadEqualsMatrixGroup(mg2, mg1)
 
-    @unittest.skipIf(not testSaveHugeFile, "Don't test saving a lot of rays")
+    @unittest.skipIf(not testSaveHugeFile, "Don't test saving a lot of matrices")
     def testSaveThenLoadHugeFile(self):
         fname = os.path.join(TestSaveAndLoadMatrixGroup.dirName, "hugeFile.pkl")
         spaces = [Space(10) for _ in range(500)]

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -263,7 +263,7 @@ class TestRaysSaveAndLoad(unittest.TestCase):
             os.remove(self.fileName)  # We remove the test file
 
     def testLoadFileDoesntExists(self):
-        file = r"this file\doesn't\exists"
+        file = r"this file\doesn't\exist"
         rays = Rays()
         with self.assertRaises(FileNotFoundError):
             rays.load(file)


### PR DESCRIPTION
I propose that we can save a `MatrixGroup` instance, like we do with `Rays`. I think it can be an interesting feature. That way, users can share setups by just sharing a `pickled` file, then load it and ***bam*** the setup is created without too much coding.

It can be useful for research, like sending files to other colleagues. It can also be useful for teaching purposes: instead of sending the script that builds the setup, you can only send the file with the setup saved.

It works like `Rays` saving/loading methods: we use `pickle` to save every components of the group and then we iterate on every components saved in the file to get the *original* setup. It keeps the original type of the element. For instance, it knows if the original component was a `Lens` or `ThickLens`, it does not only save the ABCD matrix.

It is fully tested.

I think it is a key enhancement.