### PR TITLE
Allow for OnlyAxialRays and new design parameters handler

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -87,7 +87,7 @@ class ImagingPath(MatrixGroup):
         self.fanAngle = 0.1  # full fan angle for rays
         self.fanNumber = 9  # number of rays in fan
         self.rayNumber = 3  # number of points on object
-        self._designParams = {'rayColors': ['b', 'r', 'g'], 'onlyAxialRays': False}
+        self.designParams = {'rayColors': ['b', 'r', 'g'], 'onlyAxialRays': False}
 
         # Constants when calculating field stop
         self.precision = 0.001
@@ -913,7 +913,7 @@ class ImagingPath(MatrixGroup):
                 if key is 'rayColors':
                     assert len(value) is 3, \
                         "rayColors has to be a list with 3 elements."
-                self._designParams[key] = value
+                self.designParams[key] = value
 
     def drawRayTraces(self, axes, onlyChiefAndMarginalRays,
                       removeBlockedRaysCompletely=True):  # pragma: no cover
@@ -932,7 +932,7 @@ class ImagingPath(MatrixGroup):
 
         """
 
-        color = self._designParams['rayColors']
+        color = self.designParams['rayColors']
 
         if onlyChiefAndMarginalRays:
             halfHeight = self._objectHeight / 2.0
@@ -940,7 +940,7 @@ class ImagingPath(MatrixGroup):
             (marginalUp, marginalDown) = self.marginalRays(y=0)
             rayGroup = (chiefRay, marginalUp)
             linewidth = 1.5
-        elif self._designParams['onlyAxialRays']:
+        elif self.designParams['onlyAxialRays']:
             halfAngle = self.fanAngle / 2.0
             halfHeight = self._objectHeight / 2.0
             rayGroup = Ray.fanGroup(

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -87,7 +87,8 @@ class ImagingPath(MatrixGroup):
         self.fanAngle = 0.1  # full fan angle for rays
         self.fanNumber = 9  # number of rays in fan
         self.rayNumber = 3  # number of points on object
-        self.designParams = {'rayColors': ['b', 'r', 'g'], 'onlyAxialRays': False}
+        self.designParams = {'rayColors': ['b', 'r', 'g'], 'onlyAxialRays': False,
+                             'imageColor': 'r', 'objectColor': 'b'}
 
         # Constants when calculating field stop
         self.precision = 0.001
@@ -890,8 +891,8 @@ class ImagingPath(MatrixGroup):
 
         fig.savefig(filepath, dpi=600)
 
-    def design(self, rayColors: List[str] = None,
-               onlyAxialRays: bool = None):
+    def design(self, rayColors: List[Union[str, tuple]] = None, onlyAxialRays: bool = None,
+               imageColor: Union[str, tuple] = None, objectColor: Union[str, tuple] = None):
         # todo: move to FigureManager
         # todo: maybe move all display() arguments here instead
         """ Update the design parameters of the figure.
@@ -900,11 +901,15 @@ class ImagingPath(MatrixGroup):
 
         Parameters
         ----------
-        rayColors : List[str], optional
+        rayColors : List[Union[str, tuple]], optional
             List of the colors to use for the three different ray type (. Default is ['b', 'r', 'g'].
         onlyAxialRays : bool, optional
             Only draw the ray fans coming from the center of the object (axial rays).
             Works with fanAngle and fanNumber. Default to False.
+        imageColor : Union[str, tuple], optional
+            Color of image arrows. Default to 'r'.
+        objectColor : Union[str, tuple], optional
+            Color of object arrow. Default to 'b'.
         """
 
         params = locals()
@@ -1048,8 +1053,8 @@ class ImagingPath(MatrixGroup):
             0,
             self._objectHeight,
             width=arrowHeadWidth / 5,
-            fc='b',
-            ec='b',
+            fc=self.designParams['objectColor'],
+            ec=self.designParams['objectColor'],
             head_length=arrowHeadHeight,
             head_width=arrowHeadWidth,
             length_includes_head=True)
@@ -1081,8 +1086,8 @@ class ImagingPath(MatrixGroup):
                 0,
                 magnification * self._objectHeight,
                 width=arrowHeadWidth / 5,
-                fc='r',
-                ec='r',
+                fc=self.designParams['imageColor'],
+                ec=self.designParams['imageColor'],
                 head_length=arrowHeadHeight,
                 head_width=arrowHeadWidth,
                 length_includes_head=True)

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -87,7 +87,7 @@ class ImagingPath(MatrixGroup):
         self.fanAngle = 0.1  # full fan angle for rays
         self.fanNumber = 9  # number of rays in fan
         self.rayNumber = 3  # number of points on object
-        self.design = {'rayColors': ['b', 'r', 'g']}  # design variables accessible to the user for customization
+        self._designParams = {'rayColors': ['b', 'r', 'g'], 'onlyAxialRays': False}
 
         # Constants when calculating field stop
         self.precision = 0.001
@@ -907,7 +907,7 @@ class ImagingPath(MatrixGroup):
 
         """
 
-        color = self.design['rayColors']
+        color = self._designParams['rayColors']
 
         if onlyChiefAndMarginalRays:
             halfHeight = self._objectHeight / 2.0
@@ -915,6 +915,17 @@ class ImagingPath(MatrixGroup):
             (marginalUp, marginalDown) = self.marginalRays(y=0)
             rayGroup = (chiefRay, marginalUp)
             linewidth = 1.5
+        elif self._designParams['onlyAxialRays']:
+            halfAngle = self.fanAngle / 2.0
+            halfHeight = self._objectHeight / 2.0
+            rayGroup = Ray.fanGroup(
+                yMin=0,
+                yMax=0,
+                M=self.rayNumber,
+                radianMin=-halfAngle,
+                radianMax=halfAngle,
+                N=self.fanNumber)
+            linewidth = 0.5
         else:
             halfAngle = self.fanAngle / 2.0
             halfHeight = self._objectHeight / 2.0

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Union, List
 
 from .matrixgroup import *
 
@@ -889,6 +889,31 @@ class ImagingPath(MatrixGroup):
         axes.set_ylim([-self.displayRange(axes) / 2 * 1.5, self.displayRange(axes) / 2 * 1.5])
 
         fig.savefig(filepath, dpi=600)
+
+    def design(self, rayColors: List[str] = None,
+               onlyAxialRays: bool = None):
+        # todo: move to FigureManager
+        # todo: maybe move all display() arguments here instead
+        """ Update the design parameters of the figure.
+
+        All parameters are None by default to allow for the update of one parameter at a time.
+
+        Parameters
+        ----------
+        rayColors : List[str], optional
+            List of the colors to use for the three different ray type (. Default is ['b', 'r', 'g'].
+        onlyAxialRays : bool, optional
+            Only draw the ray fans coming from the center of the object (axial rays).
+            Works with fanAngle and fanNumber. Default to False.
+        """
+
+        params = locals()
+        for key, value in params.items():
+            if value is not None:
+                if key is 'rayColors':
+                    assert len(value) is 3, \
+                        "rayColors has to be a list with 3 elements."
+                self._designParams[key] = value
 
     def drawRayTraces(self, axes, onlyChiefAndMarginalRays,
                       removeBlockedRaysCompletely=True):  # pragma: no cover


### PR DESCRIPTION
Added **new design parameters** by Valerie's request. 
- `onlyAxialRays` : only show the rays coming from the center of the object.
- `imageColor` : color used for the arrow of all images. 
- `objectColor`

The design parameters can now be updated with a **new method** like so:
```
path = ImagingPath()
path.design(rayColors=['r', 'r', 'r'], onlyAxialRays=True)
```
This adds the benefit of autocompletion since the design method holds all design parameters. 
It doesn't really change the API yet since rayColors was not being used. 