### PR TITLE
Rework tests of save/load Rays

### DIFF
--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -250,17 +250,25 @@ class TestRays(unittest.TestCase):
 
 
 class TestRaysSaveAndLoad(unittest.TestCase):
+    dirName = ""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dirName = "tempDir"
+        os.mkdir(cls.dirName)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        for file in os.listdir(cls.dirName):
+            os.remove(os.path.join(cls.dirName, file))
+        os.rmdir(cls.dirName)
 
     def setUp(self) -> None:
         self.testRays = Rays([Ray(), Ray(1, 1), Ray(-1, 1), Ray(-1, -1)])
-        self.fileName = 'testFile.pkl'
+        self.fileName = os.path.join(TestRaysSaveAndLoad.dirName, 'testFile.pkl')
         with open(self.fileName, 'wb') as file:
             pickle.Pickler(file).dump(self.testRays.rays)
         time.sleep(0.5)  # Make sure everything is ok
-
-    def tearDown(self) -> None:
-        if os.path.exists(self.fileName):
-            os.remove(self.fileName)  # We remove the test file
 
     def testLoadFileDoesntExists(self):
         file = r"this file\doesn't\exists"
@@ -294,43 +302,29 @@ class TestRaysSaveAndLoad(unittest.TestCase):
 
     def testLoadWrongFileContent(self):
         wrongObj = 7734
-        fileName = 'wrongObj.pkl'
+        fileName = os.path.join(TestRaysSaveAndLoad.dirName, 'wrongObj.pkl')
         with open(fileName, 'wb') as file:
             pickle.Pickler(file).dump(wrongObj)
         time.sleep(0.5)  # Make sure everything is ok
-
-        try:
-            with self.assertRaises(IOError):
-                Rays().load(fileName)
-        except AssertionError as exception:
-            self.fail(str(exception))
-        finally:
-            os.remove(fileName)
+        with self.assertRaises(IOError):
+            Rays().load(fileName)
 
         wrongIterType = [Ray(), Ray(1), [1, 1]]
         with open(fileName, 'wb') as file:
             pickle.Pickler(file).dump(wrongIterType)
         time.sleep(0.5)
-        try:
-            with self.assertRaises(IOError):
-                Rays().load(fileName)
-        except AssertionError as exception:
-            self.fail(str(exception))
-        finally:
-            os.remove(fileName)
+        with self.assertRaises(IOError):
+            Rays().load(fileName)
 
-    def assertSaveNotFailed(self, rays: Rays, name: str, deleteNow: bool = True):
+    def assertSaveNotFailed(self, rays: Rays, name: str):
         try:
             rays.save(name)
         except Exception as exception:
             self.fail(f"An exception was raised:\n{exception}")
-        finally:
-            if os.path.exists(name) and deleteNow:
-                os.remove(name)  # We delete the temp file
 
     def testSaveInEmptyFile(self):
         rays = Rays([Ray(), Ray(1, 1), Ray(-1, 1)])
-        name = "emptyFile.pkl"
+        name = os.path.join(TestRaysSaveAndLoad.dirName, "emptyFile.pkl")
         self.assertSaveNotFailed(rays, name)
 
     def testSaveInFileNotEmpty(self):
@@ -339,32 +333,31 @@ class TestRaysSaveAndLoad(unittest.TestCase):
 
     @unittest.skipIf(not testSaveHugeFile, "Don't test saving a lot of rays")
     def testSaveHugeFile(self):
+        fname = os.path.join(TestRaysSaveAndLoad.dirName, "hugeFile.pkl")
         nbRays = 100_000
         raysList = [Ray(y, y / nbRays) for y in range(nbRays)]
         rays = Rays(raysList)
-        self.assertSaveNotFailed(rays, "hugeFile.pkl")
+        self.assertSaveNotFailed(rays, fname)
 
     def testSaveThenLoad(self):
         raysList = [Ray(), Ray(-1), Ray(2), Ray(3)]
         rays = Rays(raysList)
-        name = "testSaveAndLoad.pkl"
-        self.assertSaveNotFailed(rays, name, False)
+        name = os.path.join(TestRaysSaveAndLoad.dirName, "testSaveAndLoad.pkl")
+        self.assertSaveNotFailed(rays, name)
         raysLoad = Rays()
         self.assertLoadNotFailed(raysLoad, name)
         self.assertListEqual(raysLoad.rays, rays.rays)
-        os.remove(name)
 
     @unittest.skipIf(not testSaveHugeFile, "Don't test saving then loading a lot of rays")
     def testSaveThenLoadHugeFile(self):
         nbRays = 100_000
         raysList = [Ray(y, y / nbRays) for y in range(nbRays)]
         rays = Rays(raysList)
-        name = "hugeFile.pkl"
-        self.assertSaveNotFailed(rays, name, False)
+        name = os.path.join(TestRaysSaveAndLoad.dirName, "hugeFile.pkl")
+        self.assertSaveNotFailed(rays, name)
         raysLoad = Rays()
         self.assertLoadNotFailed(raysLoad, name)
         self.assertListEqual(raysLoad.rays, rays.rays)
-        os.remove(name)
 
 
 if __name__ == '__main__':

--- a/raytracing/tests/testsRays.py
+++ b/raytracing/tests/testsRays.py
@@ -284,23 +284,31 @@ class TestRaysSaveAndLoad(unittest.TestCase):
         except Exception as exception:
             self.fail(f"An exception was raised:\n{exception}")
 
-    def testLoad(self):
+    def testLoadNoInitialArgs(self):
         rays = Rays()
         self.assertLoadNotFailed(rays)
         self.assertListEqual(rays.rays, self.testRays.rays)
-        rays._rays = []
+
+    def testLoadEmptyList(self):
+        rays = Rays()
         self.assertLoadNotFailed(rays)
         self.assertListEqual(rays.rays, self.testRays.rays)
 
-        finalRays = self.testRays.rays[:]  # We copy with [:]
+    def testLoadAppend(self):
+        initialRays = [Ray(), Ray(1, 1), Ray(1), Ray(0, 1)]
+        rays = Rays(initialRays)
+        finalRays = initialRays[:]  # We copy with [:]
         finalRays.extend(self.testRays.rays[:])
         self.assertLoadNotFailed(rays, append=True)  # We append
         self.assertListEqual(rays.rays, finalRays)
 
+    def testLoadOverride(self):
+        initialRays = [Ray(), Ray(1, 1), Ray(1), Ray(0, 1)]
+        rays = Rays(initialRays)
         self.assertLoadNotFailed(rays)  # We don't append, we override
         self.assertListEqual(rays.rays, self.testRays.rays)
 
-    def testLoadWrongFileContent(self):
+    def testLoadWrongIterable(self):
         wrongObj = 7734
         fileName = os.path.join(TestRaysSaveAndLoad.dirName, 'wrongObj.pkl')
         with open(fileName, 'wb') as file:
@@ -309,6 +317,8 @@ class TestRaysSaveAndLoad(unittest.TestCase):
         with self.assertRaises(IOError):
             Rays().load(fileName)
 
+    def testLoadWrongTypeInIterable(self):
+        fileName = os.path.join(TestRaysSaveAndLoad.dirName, 'wrongObj.pkl')
         wrongIterType = [Ray(), Ray(1), [1, 1]]
         with open(fileName, 'wb') as file:
             pickle.Pickler(file).dump(wrongIterType)
@@ -343,8 +353,8 @@ class TestRaysSaveAndLoad(unittest.TestCase):
         raysList = [Ray(), Ray(-1), Ray(2), Ray(3)]
         rays = Rays(raysList)
         name = os.path.join(TestRaysSaveAndLoad.dirName, "testSaveAndLoad.pkl")
-        self.assertSaveNotFailed(rays, name)
         raysLoad = Rays()
+        self.assertSaveNotFailed(rays, name)
         self.assertLoadNotFailed(raysLoad, name)
         self.assertListEqual(raysLoad.rays, rays.rays)
 
@@ -353,9 +363,9 @@ class TestRaysSaveAndLoad(unittest.TestCase):
         nbRays = 100_000
         raysList = [Ray(y, y / nbRays) for y in range(nbRays)]
         rays = Rays(raysList)
+        raysLoad = Rays()
         name = os.path.join(TestRaysSaveAndLoad.dirName, "hugeFile.pkl")
         self.assertSaveNotFailed(rays, name)
-        raysLoad = Rays()
         self.assertLoadNotFailed(raysLoad, name)
         self.assertListEqual(raysLoad.rays, rays.rays)
 


### PR DESCRIPTION
The whole creating/deleting test files was kind of messy, so I rewrote some code and reformat some tests. Temporary files are now created in their own temporary directory, which is then cleared and deleted at the end of the tests.