### PR TITLE
Fixe the test that check if a warning is printed when we generate rays for more than 3 seconds

### DIFF
--- a/raytracing/tests/testsRaysSubclasses.py
+++ b/raytracing/tests/testsRaysSubclasses.py
@@ -103,16 +103,25 @@ class TestRandomRays(unittest.TestCase):
             self.fail("This should not raise any exception.")
         self.assertEqual(ray, Ray())
 
-    @unittest.expectedFailure
-    # FIXME: Rays now warns only when it takes a long time (more than 3 seconds)
     def testRandomRaysGetWarnsWhenGeneratingRaysOnlyForLongTimes(self):
-        rays = RandomRays()
-        with self.assertRaises(UserWarning):
-            # Can't use assertWarns because an exception is raised after
-            # We must 'raise' the warning as an exception before the other exception
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("error")
-                rays[10000]
+
+        class RandomRaysTest(RandomRays):
+
+            def __init__(self, maxCount: int = 10_000):
+                super(RandomRaysTest, self).__init__(maxCount=maxCount)
+
+            def randomRay(self):
+                if len(self._rays) == self.maxCount:
+                    raise AttributeError("Cannot generate more random rays, maximum count achieved")
+                ray = Ray()  # Just the basic y = theta = 0 ray
+                time.sleep(1)  # Make it sleep for 1 second
+                self.append(ray)
+                return ray
+
+        rays = RandomRaysTest(int(1e6))
+        
+        with self.assertWarns(UserWarning):
+            rays[3]
 
     def testRandomRaysGetNotImplemented(self):
         rays = RandomRays()


### PR DESCRIPTION
I created a temporary class in the test case that inherits from `RandomRays` and overrides `randomRay` so the methods doesn't raise any exception and we can then create rays and check if there is a warning.