### PR TITLE
Finish work on MatrixGroup setitem, insert, etc

### DIFF
--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -100,11 +100,12 @@ class MatrixGroup(Matrix):
         return self.elements[item]
 
     def pop(self, index: int):
-        self.elements.pop(index)  # We pop the matrix in the list
+        poppedElement = self.elements.pop(index)  # We pop the matrix in the list
         tempElements = self.elements[:]  # We "copy" the list
         self.elements.clear()  # We clear the attribute
         for element in tempElements:
             self.append(element)  # We rebuild the attribute (check indices, compute ABCD, etc)
+        return poppedElement
 
     def insert(self, index: int, element: Matrix):
         if not isinstance(element, collections.Iterable):
@@ -119,9 +120,13 @@ class MatrixGroup(Matrix):
 
     def __setitem__(self, key, value: Matrix):
         if isinstance(key, slice):
-            if key.step is not None:
+            if key.step is not None and key.step != 1:
                 warnings.warn("Not using the step of the slice.", UserWarning)
-            self.elements = self.elements[:key.start] + self.elements[key.stop:]
+            if key.start is None:
+                key = slice(0, key.stop)
+            if key.stop is None:
+                key = slice(key.start, len(self))
+            self.elements = self.elements[:key.start] + self.elements[key.stop:]  # "Cut" the original list
             self.insert(key.start, value)
         else:
             self.pop(key)

--- a/raytracing/tests/testsMatrixGroup.py
+++ b/raytracing/tests/testsMatrixGroup.py
@@ -369,134 +369,150 @@ class TestMatrixGroup(envtest.RaytracingTestCase):
         self.assertIsInstance(sliceMG, MatrixGroup)
         self.assertListEqual(sliceMG.elements, mg.elements)
 
-    def testRemoveElementPositiveIndexOutOfBounds(self):
-        nbElements = 10
-        mg = MatrixGroup([Lens(10) for _ in range(nbElements)])
+    def testPopPositiveIndexOutOfBounds(self):
+        mg = MatrixGroup([Lens(5)])
         with self.assertRaises(IndexError):
-            mg.pop(len(mg))
+            mg.pop(2)
 
-    def testRemoveElementNegativeIndexOutOfBounds(self):
-        nbElements = 10
-        mg = MatrixGroup([Lens(10) for _ in range(nbElements)])
+    def testPopNegativeIndexOutOfBounds(self):
+        mg = MatrixGroup([Lens(5)])
         with self.assertRaises(IndexError):
-            mg.pop(-(len(mg) + 1))
+            mg.pop(-2)
 
-    def testRemoveElementLastNoPad(self):
-        space = Space(10)
+    def testPopFirstElement(self):
         lens = Lens(10)
-        listOfElements = [space, lens, space]
-        mg1 = MatrixGroup(listOfElements)
-        mg2 = MatrixGroup(listOfElements)
-        mg1.pop(-1)
-        mg2.pop((len(mg2) - 1))
-        self.assertListEqual(mg1.elements, [space, lens])
-        self.assertListEqual(mg1.elements, mg2.elements)
-
-    def testRemoveElementFirstNoPad(self):
-        space = Space(10)
-        lens = Lens(10)
-        listOfElements = [space, lens, space]
-        mg1 = MatrixGroup(listOfElements)
-        mg2 = MatrixGroup(listOfElements)
-        mg1.pop(0)
-        mg2.pop(-len(mg2))
-        self.assertListEqual(mg1.elements, [lens, space])
-        self.assertListEqual(mg1.elements, mg2.elements)
-
-    def testRemoveAllNoPad(self):
-        space = Space(10)
-        lens = Lens(10)
-        listOfElements = [space, lens, space]
-        mg = MatrixGroup(listOfElements)
-        mg.pop(1)
-        mg.pop(0)
-        mg.pop(0)
+        mg = MatrixGroup([lens])
+        poppedElement = mg.pop(0)
+        self.assertEqual(poppedElement, lens)
         self.assertListEqual(mg.elements, [])
 
-    def testRemoveElementPad(self):
+    def testPopLastElement(self):
         space = Space(10)
         lens = Lens(10)
-        listOfElements = [space, lens, space]
-        mg1 = MatrixGroup(listOfElements)
-        mg2 = MatrixGroup(listOfElements)
-        mg3 = MatrixGroup(listOfElements)
-        mg1.pop(0, True)
-        mg2.pop(1, True)
-        mg3.pop(2, True)
-        self.assertIsInstance(mg1[0], Space)
-        self.assertEqual(mg1[0].L, 10)
-        self.assertEqual(len(mg2), 2)
-        self.assertIsInstance(mg1[2], Space)
-        self.assertEqual(mg1[2].L, 10)
+        mg = MatrixGroup([space, lens, space])
+        poppedElement = mg.pop(2)
+        self.assertEqual(poppedElement, space)
+        self.assertListEqual(mg.elements, [space, lens])
 
-    def testInsertElementNotMatrix(self):
-        mg = MatrixGroup()
-        with self.assertRaises(TypeError):
-            mg.insert(0, Ray())
-
-    def testInsertElementNegativeIndexOutOfBounds(self):
-        mg = MatrixGroup([Lens(10)])
-        with self.assertRaises(IndexError):
-            mg.insert(-2, Space(10))
-
-    def testInsertElementPositiveIndexOutOfBounds(self):
-        mg = MatrixGroup([Lens(10)])
-        with self.assertRaises(IndexError):
-            mg.insert(2, Space(10))
-
-    def testInsertElementAtTheEnd(self):
-        space = Space(10)
-        lens = Lens(10)
-        mg = MatrixGroup([space, lens])
-        mg.insert(2, space)
-        self.assertListEqual(mg.elements, [space, lens, space])
-
-    def testInsertElementAtFirst(self):
-        space = Space(10)
-        lens = Lens(10)
-        mg = MatrixGroup([lens, space])
-        mg.insert(0, space)
-        self.assertListEqual(mg.elements, [space, lens, space])
-
-    def testInsertElementIterable(self):
-        space = Space(10)
-        lens = Lens(10)
-        mg = MatrixGroup([space, space, lens, space])
-        insertion = MatrixGroup([lens, space])
-        mg.insert(1, insertion)
-        self.assertListEqual(mg.elements, [space, lens, space, space, lens, space])
-
-    def testSetPositiveSingleIndexOutOfBounds(self):
-        mg = MatrixGroup([Space(10), Lens(10), Space(10), Space(5), ThickLens(1.33, 10, -10, 2)])
-        with self.assertRaises(IndexError):
-            mg[12] = CurvedMirror(5, 20)
-
-    def testSetPositiveSliceOutOfBounds(self):
-        mg = MatrixGroup([Space(10), Lens(10), Space(10), Space(5), ThickLens(1.33, 10, -10, 2)])
-        with self.assertRaises(IndexError):
-            mg[10:12] = Aperture(50)  # First index out of bounds
-
-        with self.assertRaises(IndexError):
-            mg[0:10] = Aperture(80)  # Second index out of bounds
-
-    def testSetNegativeSliceOutOfBounds(self):
-        mg = MatrixGroup([Space(10), Lens(10), Space(10), Space(5), ThickLens(1.33, 10, -10, 2)])
-        with self.assertRaises(IndexError):
-            mg[-20:-1] = Aperture(50)
-
-        with self.assertRaises(IndexError):
-            mg[-1:-7] = Aperture(100)
-
-    def testSetStepWarning(self):
+    def testPopElements(self):
         space10 = Space(10)
         lens10 = Lens(10)
         space5 = Space(5)
         lens5 = Lens(5)
-        mg = MatrixGroup([space10, lens10, space5, space10, ThickLens(1.33, 10, -10, 2), space5])
-        with self.assertWarns(UserWarning) as w:
-            mg[2:4:2] = [space10, space5, lens5]
-        self.assertEqual(str(w.warning), "Not using the step of the slice.")
-        self.assertListEqual(mg.elements, [space10, lens10, space10, space5, lens5, space5])
+        mg = MatrixGroup([space5, lens5, space5, space10, lens10, space10])
+        pop3 = mg.pop(3)
+        popLast = mg.pop(-1)
+        self.assertEqual(pop3, popLast)
+        self.assertListEqual(mg.elements, [space5, lens5, space5, lens10])
+
+    def testInsertPositiveIndexOutOfBoundsNoError(self):
+        space = Space(10)
+        mg = MatrixGroup()
+        mg.insert(10, space)
+        self.assertListEqual(mg.elements, [space])
+
+    def testInsertNegativeIndexOutOfBoundsNoErrors(self):
+        space = Space(10)
+        mg = MatrixGroup()
+        mg.insert(-1000, space)
+        self.assertListEqual(mg.elements, [space])
+
+    def testInsertBeforeFirst(self):
+        space10 = Space(10)
+        lens10 = Lens(10)
+        space20 = Space(20)
+        lens20 = Lens(20)
+        space5 = Space(5)
+        lens5 = Lens(5)
+        space15 = Space(15)
+        lens15 = Lens(15)
+        mg = MatrixGroup([space10, lens10, space10, space20, lens20, space20, space5, lens5, space5])
+        mg.insert(0, [lens15, space15, lens15])
+        allElements = [lens15, space15, lens15, space10, lens10, space10, space20, lens20, space20, space5, lens5,
+                       space5]
+        self.assertListEqual(mg.elements, allElements)
+
+    def testInsertAfterLast(self):
+        space10 = Space(10)
+        lens10 = Lens(10)
+        space20 = Space(20)
+        lens20 = Lens(20)
+        space5 = Space(5)
+        lens5 = Lens(5)
+        space15 = Space(15)
+        lens15 = Lens(15)
+        mg = MatrixGroup([space10, lens10, space10, space20, lens20, space20, space5, lens5, space5])
+        mg.insert(10, [lens15, space15, lens15])
+        allElements = [space10, lens10, space10, space20, lens20, space20, space5, lens5,
+                       space5, lens15, space15, lens15]
+        self.assertListEqual(mg.elements, allElements)
+
+    def testInsertInMiddle(self):
+        space10 = Space(10)
+        lens10 = Lens(10)
+        mg = MatrixGroup([space10, space10])
+        mg.insert(1, lens10)
+        self.assertListEqual(mg.elements, [space10, lens10, space10])
+
+    def testSetItemSingleIndexOutOfBounds(self):
+        mg = MatrixGroup()
+        with self.assertRaises(IndexError):
+            mg[0] = Lens(100)
+
+    def testSetItemSliceIndexOutOfBounds(self):
+        lens = Lens(10)
+        space = Space(10)
+        mg = MatrixGroup()
+        mg[0:2] = [space, lens, space]
+        self.assertListEqual(mg.elements, [space, lens, space])
+
+    def testSetItemSliceWithStepWarning(self):
+        lens = Lens(10)
+        space = Space(10)
+        mg = MatrixGroup([space, lens, space, Space(20), Lens(20), Space(20)])
+        with self.assertWarns(UserWarning):
+            mg[3:len(mg):2] = [space, lens, space]
+        self.assertListEqual(mg.elements, [space, lens, space, space, lens, space])
+
+    def testSetItemSliceWithStepIsOne(self):
+        lens = Lens(10)
+        space = Space(10)
+        mg = MatrixGroup([space, lens, space, Space(20), Lens(20), Space(20)])
+        try:
+            with self.assertWarns(UserWarning):
+                mg[3:len(mg):1] = [space, lens, space]
+        except AssertionError:
+            self.assertListEqual(mg.elements, [space, lens, space, space, lens, space])
+        else:
+            self.fail("This should not print any warning!")
+
+    def testSetItemStartIndexIsNone(self):
+        lens = Lens(10)
+        space = Space(10)
+        mg = MatrixGroup([Space(20), Lens(20), space])
+        mg[:2] = [space, lens]
+        self.assertListEqual(mg.elements, [space, lens, space])
+
+    def testSetItemStopIndexIsNone(self):
+        lens = Lens(10)
+        space = Space(10)
+        mg = MatrixGroup([space, Lens(20), Space(20)])
+        mg[1:] = [lens, space]
+        self.assertListEqual(mg.elements, [space, lens, space])
+
+    def testSetItemAll(self):
+        lens = Lens(10)
+        space = Space(10)
+        mg = MatrixGroup([CurvedMirror(10), DielectricInterface(1, 1.33), Space(20, 1.33)])
+        mg[:] = [space, lens, space]
+        self.assertListEqual(mg.elements, [space, lens, space])
+
+    def testSetItemSingleIndex(self):
+        lens = Lens(10)
+        space = Space(10)
+        mg = MatrixGroup([CurvedMirror(10), lens, space])
+        mg[0] = space
+        self.assertListEqual(mg.elements, [space, lens, space])
 
 
 class TestSaveAndLoadMatrixGroup(envtest.RaytracingTestCase):


### PR DESCRIPTION
I was not completely done when pull request #236 was merged into `master`. This fixes some issues with `__setitem__` and has all missing tests.