### PR TITLE
Do not limit object to FOV if object height was set by user

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -17,7 +17,8 @@ class Figure:
 
         self.styles = dict()
         self.styles['default'] = {'rayColors': ['b', 'r', 'g'], 'onlyAxialRay': False,
-                                  'imageColor': 'r', 'objectColor': 'b', 'onlyPrincipalAndAxialRays': True}
+                                  'imageColor': 'r', 'objectColor': 'b', 'onlyPrincipalAndAxialRays': True,
+                                  'limitObjectToFieldOfView': True}
         self.styles['publication'] = self.styles['default'].copy()
         self.styles['presentation'] = self.styles['default'].copy()  # same as default for now
 
@@ -37,36 +38,28 @@ class Figure:
 
         self.axes.set(xlabel='Distance', ylabel='Height', title=title)
 
-    def initializeDisplay(self, limitObjectToFieldOfView=True):
-        """
-        Configure the imaging path and the figure according to the display conditions.
-
-        Other parameters
-        ----------------
-        limitObjectToFieldOfView: bool
-            Use the calculated field of view instead of the objectHeight. Default to True.
-
-        """
+    def initializeDisplay(self):
+        """ Configure the imaging path and the figure according to the display conditions. """
 
         note1 = ""
         note2 = ""
-        if limitObjectToFieldOfView:
+        if self.designParams['limitObjectToFieldOfView']:
             fieldOfView = self.path.fieldOfView()
             if fieldOfView != float('+Inf'):
                 self.path.objectHeight = fieldOfView
                 note1 = "FOV: {0:.2f}".format(self.path.objectHeight)
             else:
                 warnings.warn("Infinite field of view: cannot use limitObjectToFieldOfView=True.")
-                limitObjectToFieldOfView = False
+                self.designParams['limitObjectToFieldOfView'] = False
 
             imageSize = self.path.imageSize()
             if imageSize != float('+Inf'):
                 note1 += " Image size: {0:.2f}".format(imageSize)
             else:
                 warnings.warn("Infinite image size: cannot use limitObjectToFieldOfView=True.")
-                limitObjectToFieldOfView = False
+                self.designParams['limitObjectToFieldOfView'] = False
 
-        if not limitObjectToFieldOfView:
+        if not self.designParams['limitObjectToFieldOfView']:
             note1 = "Object height: {0:.2f}".format(self.path.objectHeight)
 
         if self.designParams['onlyPrincipalAndAxialRays']:
@@ -123,15 +116,12 @@ class Figure:
                         "rayColors has to be a list with 3 elements."
                 self.designParams[key] = value
 
-    def display(self, limitObjectToFieldOfView=True, onlyPrincipalAndAxialRays=True,
+    def display(self, onlyPrincipalAndAxialRays=True,
                 removeBlockedRaysCompletely=False, filepath=None):
         """ Display the optical system and trace the rays.
 
         Parameters
         ----------
-        limitObjectToFieldOfView : bool (Optional)
-            If True, the object will be limited to the field of view and
-            the calculated field of view will be used instead of the objectHeight(default=True)
         onlyPrincipalAndAxialRays : bool (Optional)
             If True, only the principal ray and the axial ray will appear on the plot (default=True)
         removeBlockedRaysCompletely : bool (Optional)
@@ -140,7 +130,7 @@ class Figure:
         """
 
         self.designParams['onlyPrincipalAndAxialRays'] = onlyPrincipalAndAxialRays
-        self.initializeDisplay(limitObjectToFieldOfView=limitObjectToFieldOfView)
+        self.initializeDisplay()
 
         self.drawLines(self.rayTraceLines(removeBlockedRaysCompletely=removeBlockedRaysCompletely))
         self.drawDisplayObjects()

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -677,8 +677,9 @@ class ImagingPath(MatrixGroup):
 
         return super(ImagingPath, self).lagrangeInvariant(z=z, ray1=ray1, ray2=ray2)
 
-    def display(self, limitObjectToFieldOfView=True, onlyPrincipalAndAxialRays=True,
-                removeBlockedRaysCompletely=False, comments=None, onlyChiefAndMarginalRays=None):
+    def display(self, onlyPrincipalAndAxialRays=True,
+                removeBlockedRaysCompletely=False, comments=None,
+                limitObjectToFieldOfView=None, onlyChiefAndMarginalRays=None):
         """ Display the optical system and trace the rays.
 
         Parameters
@@ -698,18 +699,18 @@ class ImagingPath(MatrixGroup):
             warnings.warn(" Usage of onlyChiefAndMarginalRays is deprecated, "
                           "use onlyPrincipalAndAxialRays instead.")
             onlyPrincipalAndAxialRays = onlyChiefAndMarginalRays
+        if limitObjectToFieldOfView is not None:
+            self.figure.designParams['limitObjectToFieldOfView'] = limitObjectToFieldOfView
 
         self.figure.createFigure(title=self.label, comments=comments)
 
-        self.figure.display(limitObjectToFieldOfView=limitObjectToFieldOfView,
-                            onlyPrincipalAndAxialRays=onlyPrincipalAndAxialRays,
+        self.figure.display(onlyPrincipalAndAxialRays=onlyPrincipalAndAxialRays,
                             removeBlockedRaysCompletely=removeBlockedRaysCompletely)
 
     def save(self, filepath,
-             limitObjectToFieldOfView=True,
              onlyPrincipalAndAxialRays=True,
-             removeBlockedRaysCompletely=False,
-             comments=None):
+             removeBlockedRaysCompletely=False, comments=None,
+             limitObjectToFieldOfView=None, onlyChiefAndMarginalRays=None):
         """
         The figure of the imaging path can be saved using this function.
 
@@ -729,12 +730,16 @@ class ImagingPath(MatrixGroup):
         comments : string
             If comments are included they will be displayed on a graph in the bottom half of the plot. (default=None)
 
-
         """
+        if onlyChiefAndMarginalRays is not None:
+            warnings.warn(" Usage of onlyChiefAndMarginalRays is deprecated, "
+                          "use onlyPrincipalAndAxialRays instead.")
+            onlyPrincipalAndAxialRays = onlyChiefAndMarginalRays
+        if limitObjectToFieldOfView is not None:
+            self.figure.designParams['limitObjectToFieldOfView'] = limitObjectToFieldOfView
 
         self.figure.createFigure(title=self.label, comments=comments)
 
-        self.figure.display(limitObjectToFieldOfView=limitObjectToFieldOfView,
-                            onlyPrincipalAndAxialRays=onlyPrincipalAndAxialRays,
+        self.figure.display(onlyPrincipalAndAxialRays=onlyPrincipalAndAxialRays,
                             removeBlockedRaysCompletely=removeBlockedRaysCompletely,
                             filepath=filepath)

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -115,6 +115,7 @@ class ImagingPath(MatrixGroup):
         if objectHeight < 0:
             raise ValueError("The object height can't be negative.")
         self._objectHeight = objectHeight
+        self.figure.designParams['limitObjectToFieldOfView'] = False
 
     def chiefRay(self, y=None):
         """This function returns the chief ray for a height y at object.


### PR DESCRIPTION
This requires a variable in memory so I added the `limitObjectToFieldOfView` in the design parameters of the figure. 