### PR TITLE
Update imagingpath.py

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -422,7 +422,7 @@ class ImagingPath(MatrixGroup):
                 return None, None
             else:
                 (Mt, Ma) = matrixToPupil.magnification()
-                return (-pupilPosition, stopDiameter / Mt)
+                return (-pupilPosition, stopDiameter / abs(Mt))
         else:
             return (None, None)
 


### PR DESCRIPTION
We must use  the  absolute value of the magnification to calculate the pupil size.