### PR TITLE
Fix issue #186: ignore images out of the optical path in displayRange

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -180,9 +180,10 @@ class Figure:
         conjugates = self.path.intermediateConjugates()
         if len(conjugates) != 0:
             for (planePosition, magnification) in conjugates:
-                magnification = abs(magnification)
-                if displayRange < self.path._objectHeight * magnification:
-                    displayRange = self.path._objectHeight * magnification
+                if self.axes.get_xlim()[0] <= planePosition <= self.axes.get_xlim()[1]:
+                    magnification = abs(magnification)
+                    if displayRange < self.path._objectHeight * magnification:
+                        displayRange = self.path._objectHeight * magnification
 
         return displayRange
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -180,10 +180,11 @@ class Figure:
         conjugates = self.path.intermediateConjugates()
         if len(conjugates) != 0:
             for (planePosition, magnification) in conjugates:
-                if self.axes.get_xlim()[0] <= planePosition <= self.axes.get_xlim()[1]:
-                    magnification = abs(magnification)
-                    if displayRange < self.path._objectHeight * magnification:
-                        displayRange = self.path._objectHeight * magnification
+                if not 0 <= planePosition <= self.path.L:
+                    continue
+                magnification = abs(magnification)
+                if displayRange < self.path._objectHeight * magnification:
+                    displayRange = self.path._objectHeight * magnification
 
         return displayRange
 

--- a/raytracing/tests/testsFigure.py
+++ b/raytracing/tests/testsFigure.py
@@ -14,12 +14,12 @@ class TestFigure(unittest.TestCase):
 
         self.assertEqual(path.figure.displayRange(), largestDiameter)
 
-    def testDisplayRange(self):
+    def testDisplayRangeImageOutOfView(self):
         path = ImagingPath()
         path.append(Space(2))
         path.append(CurvedMirror(-5, 10))
 
-        self.assertAlmostEqual(path.figure.displayRange(), 5 * 10)
+        self.assertAlmostEqual(path.figure.displayRange(), 20)
 
         path.objectHeight = 1
         self.assertEqual(path.figure.displayRange(), 10)


### PR DESCRIPTION
Fixes #186 