### PR TITLE
Fixed Figure to use the correct nomenclature for principalRay and axial

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -424,9 +424,9 @@ class Figure:
 
         if self.designParams['onlyPrincipalAndAxialRays']:
             halfHeight = self.path.objectHeight / 2.0
-            chiefRay = self.path.chiefRay(y=halfHeight - 0.01)  # fixme: refactor required for the renaming of rays
-            (marginalUp, marginalDown) = self.path.marginalRays(y=0)
-            rayGroup = (chiefRay, marginalUp)
+            principalRay = self.path.principalRay()
+            axialRay = self.path.axialRay()
+            rayGroup = (principalRay, axialRay)
             linewidth = 1.5
         else:
             halfAngle = self.path.fanAngle / 2.0
@@ -450,9 +450,16 @@ class Figure:
                 continue  # nothing to plot, ray was fully blocked
 
             rayInitialHeight = y[0]
-            binSize = 2.0 * halfHeight / (len(color) - 1)
+            # FIXME: We must take the maximum y in the starting point of manyRayTraces,
+            # not halfHeight
+            maxStartingHeight = halfHeight # FIXME
+            binSize = 2.0 * maxStartingHeight / (len(color) - 1)
             colorIndex = int(
-                (rayInitialHeight - (-halfHeight - binSize / 2)) / binSize)
+                (rayInitialHeight - (-maxStartingHeight - binSize / 2)) / binSize)
+            if colorIndex < 0:
+                colorIndex = 0
+            elif colorIndex >= len(color):
+                colorIndex = len(color) - 1
 
             line = plt.Line2D(x, y, color=color[colorIndex], linewidth=linewidth, label='ray')
             lines.append(line)

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -180,7 +180,7 @@ class ImagingPath(MatrixGroup):
             return None
 
         if y is None:
-            y = self.fieldOfView()
+            y = self.fieldOfView()/2
             if abs(y) == float("+inf"):
                 raise ValueError("Must provide y when the field of view is infinite")
 
@@ -203,7 +203,9 @@ class ImagingPath(MatrixGroup):
         raytracing.ImagingPath.chiefRay
 
         """
-        return self.chiefRay()
+        principalRay = self.chiefRay(y=self.fieldOfView()/2)
+        principalRay.y -= 0.001
+        return principalRay
 
     def marginalRays(self, y=0):
         """This function calculates the marginal rays for a height y at object.
@@ -306,7 +308,8 @@ class ImagingPath(MatrixGroup):
         raytracing.ImagingPath.chiefRay
         raytracing.ImagingPath.principalRay
         """
-        return self.marginalRays()
+        rayUp, rayDown = self.marginalRays()
+        return rayUp
 
     def apertureStop(self):
         """The "aperture stop" is an aperture in the system that limits

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -203,7 +203,12 @@ class ImagingPath(MatrixGroup):
         raytracing.ImagingPath.chiefRay
 
         """
-        principalRay = self.chiefRay(y=self.fieldOfView()/2)
+
+        objectEdge = self.fieldOfView()/2
+        if objectEdge == float("+inf"):
+            return None
+
+        principalRay = self.chiefRay(y=objectEdge)
         principalRay.y -= 0.001 #FIXME: be more intelligent than this.
         return principalRay
 

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -187,14 +187,14 @@ class ImagingPath(MatrixGroup):
         return Ray(y=y, theta=-A * y / B)
 
     def principalRay(self):
-        """This function returns the chief ray for the height y at the edge 
-        of the field of view. The chief ray for height y is the ray that goes
-        through the center of the aperture stop.
+        """This function returns the principal ray, which is the chief ray 
+        for the height y at the edge of the field of view. The chief ray
+        is the ray that goes through the center of the aperture stop.
 
         Returns
         -------
         principalRay : object of Ray class
-            The properties (i.e. height and the angle of the marginal ray).
+            The properties (i.e. height and the angle of the principal ray).
 
         See Also
         --------
@@ -204,7 +204,7 @@ class ImagingPath(MatrixGroup):
 
         """
         principalRay = self.chiefRay(y=self.fieldOfView()/2)
-        principalRay.y -= 0.001
+        principalRay.y -= 0.001 #FIXME: be more intelligent than this.
         return principalRay
 
     def marginalRays(self, y=0):

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -192,9 +192,16 @@ class TestImagingPath(envtest.RaytracingTestCase):
         self.assertAlmostEqual(chiefRay.y, 10, 2)
         self.assertAlmostEqual(chiefRay.theta, -1, 3)
 
+    def testPrincipalRayIsNone(self):
+        path = ImagingPath()
+        path.append(System2f(f=10, diameter=float("+inf")))
+        path.append(Aperture(diameter=20))
+        principalRay = path.principalRay()
+        self.assertIsNone(principalRay, principalRay)
+
     def testPrincipalRayIsNotNone(self):
         path = ImagingPath()
-        path.append(System2f(10, 10))
+        path.append(System2f(f=10, diameter=10))
         path.append(Aperture(diameter=20))
         principalRay = path.principalRay()
         self.assertAlmostEqual(principalRay.y, 10, 2)

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -189,15 +189,6 @@ class TestImagingPath(envtest.RaytracingTestCase):
         path.append(System2f(10, 10))
         path.append(Aperture(diameter=20))
         chiefRay = path.chiefRay()
-
-    def testPrincipalRayIsNoneNoFiniteElement(self):
-        path = ImagingPath(System4f(10, 10))
-        self.assertIsNone(path.principalRay())
-
-    def testPrincipalRayIsNoneFiniteElement(self):
-        path = ImagingPath(System4f(10, 10))
-        path.append(Aperture(10))
-        self.assertIsNone(path.principalRay())
         self.assertAlmostEqual(chiefRay.y, 10, 2)
         self.assertAlmostEqual(chiefRay.theta, -1, 3)
 

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -189,8 +189,6 @@ class TestImagingPath(envtest.RaytracingTestCase):
         path.append(System2f(10, 10))
         path.append(Aperture(diameter=20))
         chiefRay = path.chiefRay()
-        self.assertAlmostEqual(chiefRay.y, 20, 2)
-        self.assertAlmostEqual(chiefRay.theta, -2, 3)
 
     def testPrincipalRayIsNoneNoFiniteElement(self):
         path = ImagingPath(System4f(10, 10))
@@ -200,14 +198,16 @@ class TestImagingPath(envtest.RaytracingTestCase):
         path = ImagingPath(System4f(10, 10))
         path.append(Aperture(10))
         self.assertIsNone(path.principalRay())
+        self.assertAlmostEqual(chiefRay.y, 10, 2)
+        self.assertAlmostEqual(chiefRay.theta, -1, 3)
 
     def testPrincipalRayIsNotNone(self):
         path = ImagingPath()
         path.append(System2f(10, 10))
         path.append(Aperture(diameter=20))
         principalRay = path.principalRay()
-        self.assertAlmostEqual(principalRay.y, 20, 2)
-        self.assertAlmostEqual(principalRay.theta, -2, 3)
+        self.assertAlmostEqual(principalRay.y, 10, 2)
+        self.assertAlmostEqual(principalRay.theta, -1, 3)
 
     def testMarginalRaysNoApertureStop(self):
         path = ImagingPath(System4f(10, 10))

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -243,13 +243,9 @@ class TestImagingPath(envtest.RaytracingTestCase):
 
     def testAxialRay(self):
         path = ImagingPath(System2f(10, 100))
-        rays = path.axialRay()
-        ray1, ray2 = rays[0], rays[1]
-        self.assertEqual(len(rays), 2)
-        self.assertEqual(ray1.y, 0)
-        self.assertEqual(ray1.theta, 5)
-        self.assertEqual(ray2.y, 0)
-        self.assertEqual(ray2.theta, -5)
+        ray = path.axialRay()
+        self.assertEqual(ray.y, 0)
+        self.assertEqual(ray.theta, 5)
 
     def testLagrangeImagingPathNoAperture(self):
         path = ImagingPath()


### PR DESCRIPTION
Regardless of limiting field of view  or not in display(), the princical ray is still the chief ray of the field of view limits.

There was a mistake in the principalRay calculation when chiefRay was not passed any parameter. It has been fixed.

Also, there is a final problem for assigning colors when drawing the rays: we must use the maximum starting height, not halfHeight.