### PR TITLE
Update API documentation stub files

### DIFF
--- a/docs/modules/methods/AchromatDoubletLens/raytracing.AchromatDoubletLens.drawAperture.rst
+++ b/docs/modules/methods/AchromatDoubletLens/raytracing.AchromatDoubletLens.drawAperture.rst
@@ -1,4 +1,0 @@
-AchromatDoubletLens.drawAperture
-================================
-
-.. autofunction:: raytracing.AchromatDoubletLens.drawAperture

--- a/docs/modules/methods/AchromatDoubletLens/raytracing.AchromatDoubletLens.drawAt.rst
+++ b/docs/modules/methods/AchromatDoubletLens/raytracing.AchromatDoubletLens.drawAt.rst
@@ -1,4 +1,0 @@
-AchromatDoubletLens.drawAt
-==========================
-
-.. autofunction:: raytracing.AchromatDoubletLens.drawAt

--- a/docs/modules/methods/Aperture/raytracing.Aperture.drawAt.rst
+++ b/docs/modules/methods/Aperture/raytracing.Aperture.drawAt.rst
@@ -1,4 +1,0 @@
-Aperture.drawAt
-===============
-
-.. autofunction:: raytracing.Aperture.drawAt

--- a/docs/modules/methods/DielectricInterface/raytracing.DielectricInterface.drawAt.rst
+++ b/docs/modules/methods/DielectricInterface/raytracing.DielectricInterface.drawAt.rst
@@ -1,4 +1,0 @@
-DielectricInterface.drawAt
-==========================
-
-.. autofunction:: raytracing.DielectricInterface.drawAt

--- a/docs/modules/methods/DielectricSlab/raytracing.DielectricSlab.drawAt.rst
+++ b/docs/modules/methods/DielectricSlab/raytracing.DielectricSlab.drawAt.rst
@@ -1,4 +1,0 @@
-DielectricSlab.drawAt
-=====================
-
-.. autofunction:: raytracing.DielectricSlab.drawAt

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.axialRay.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.axialRay.rst
@@ -1,0 +1,4 @@
+ImagingPath.axialRay
+====================
+
+.. autofunction:: raytracing.ImagingPath.axialRay

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.axialRays.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.axialRays.rst
@@ -1,4 +1,0 @@
-ImagingPath.axialRays
-=====================
-
-.. autofunction:: raytracing.ImagingPath.axialRays

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.createRayTracePlot.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.createRayTracePlot.rst
@@ -1,4 +1,0 @@
-ImagingPath.createRayTracePlot
-==============================
-
-.. autofunction:: raytracing.ImagingPath.createRayTracePlot

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.displayRange.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.displayRange.rst
@@ -1,4 +1,0 @@
-ImagingPath.displayRange
-========================
-
-.. autofunction:: raytracing.ImagingPath.displayRange

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawDisplayObjects.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawDisplayObjects.rst
@@ -1,4 +1,0 @@
-ImagingPath.drawDisplayObjects
-==============================
-
-.. autofunction:: raytracing.ImagingPath.drawDisplayObjects

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawEntrancePupil.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawEntrancePupil.rst
@@ -1,4 +1,0 @@
-ImagingPath.drawEntrancePupil
-=============================
-
-.. autofunction:: raytracing.ImagingPath.drawEntrancePupil

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawImages.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawImages.rst
@@ -1,4 +1,0 @@
-ImagingPath.drawImages
-======================
-
-.. autofunction:: raytracing.ImagingPath.drawImages

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawObject.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawObject.rst
@@ -1,4 +1,0 @@
-ImagingPath.drawObject
-======================
-
-.. autofunction:: raytracing.ImagingPath.drawObject

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawOpticalElements.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawOpticalElements.rst
@@ -1,4 +1,0 @@
-ImagingPath.drawOpticalElements
-===============================
-
-.. autofunction:: raytracing.ImagingPath.drawOpticalElements

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawRayTraces.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawRayTraces.rst
@@ -1,4 +1,0 @@
-ImagingPath.drawRayTraces
-=========================
-
-.. autofunction:: raytracing.ImagingPath.drawRayTraces

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawStops.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.drawStops.rst
@@ -1,4 +1,0 @@
-ImagingPath.drawStops
-=====================
-
-.. autofunction:: raytracing.ImagingPath.drawStops

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.principalRay.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.principalRay.rst
@@ -1,0 +1,4 @@
+ImagingPath.principalRay
+========================
+
+.. autofunction:: raytracing.ImagingPath.principalRay

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.rearrangeRayTraceForPlotting.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.rearrangeRayTraceForPlotting.rst
@@ -1,4 +1,0 @@
-ImagingPath.rearrangeRayTraceForPlotting
-========================================
-
-.. autofunction:: raytracing.ImagingPath.rearrangeRayTraceForPlotting

--- a/docs/modules/methods/ImagingPath/raytracing.ImagingPath.updateDisplay.rst
+++ b/docs/modules/methods/ImagingPath/raytracing.ImagingPath.updateDisplay.rst
@@ -1,4 +1,0 @@
-ImagingPath.updateDisplay
-=========================
-
-.. autofunction:: raytracing.ImagingPath.updateDisplay

--- a/docs/modules/methods/Lens/raytracing.Lens.drawAt.rst
+++ b/docs/modules/methods/Lens/raytracing.Lens.drawAt.rst
@@ -1,4 +1,0 @@
-Lens.drawAt
-===========
-
-.. autofunction:: raytracing.Lens.drawAt

--- a/docs/modules/methods/Matrix/raytracing.Matrix.axesToDataScale.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.axesToDataScale.rst
@@ -1,4 +1,0 @@
-Matrix.axesToDataScale
-======================
-
-.. autofunction:: raytracing.Matrix.axesToDataScale

--- a/docs/modules/methods/Matrix/raytracing.Matrix.display.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.display.rst
@@ -1,4 +1,0 @@
-Matrix.display
-==============
-
-.. autofunction:: raytracing.Matrix.display

--- a/docs/modules/methods/Matrix/raytracing.Matrix.drawAperture.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.drawAperture.rst
@@ -1,4 +1,0 @@
-Matrix.drawAperture
-===================
-
-.. autofunction:: raytracing.Matrix.drawAperture

--- a/docs/modules/methods/Matrix/raytracing.Matrix.drawAt.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.drawAt.rst
@@ -1,4 +1,0 @@
-Matrix.drawAt
-=============
-
-.. autofunction:: raytracing.Matrix.drawAt

--- a/docs/modules/methods/Matrix/raytracing.Matrix.drawCardinalPoints.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.drawCardinalPoints.rst
@@ -1,4 +1,0 @@
-Matrix.drawCardinalPoints
-=========================
-
-.. autofunction:: raytracing.Matrix.drawCardinalPoints

--- a/docs/modules/methods/Matrix/raytracing.Matrix.drawLabels.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.drawLabels.rst
@@ -1,4 +1,0 @@
-Matrix.drawLabels
-=================
-
-.. autofunction:: raytracing.Matrix.drawLabels

--- a/docs/modules/methods/Matrix/raytracing.Matrix.drawPointsOfInterest.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.drawPointsOfInterest.rst
@@ -1,4 +1,0 @@
-Matrix.drawPointsOfInterest
-===========================
-
-.. autofunction:: raytracing.Matrix.drawPointsOfInterest

--- a/docs/modules/methods/Matrix/raytracing.Matrix.drawPrincipalPlanes.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.drawPrincipalPlanes.rst
@@ -1,4 +1,0 @@
-Matrix.drawPrincipalPlanes
-==========================
-
-.. autofunction:: raytracing.Matrix.drawPrincipalPlanes

--- a/docs/modules/methods/Matrix/raytracing.Matrix.drawVertices.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.drawVertices.rst
@@ -1,4 +1,0 @@
-Matrix.drawVertices
-===================
-
-.. autofunction:: raytracing.Matrix.drawVertices

--- a/docs/modules/methods/Matrix/raytracing.Matrix.largestDiameter.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.largestDiameter.rst
@@ -1,4 +1,0 @@
-Matrix.largestDiameter
-======================
-
-.. autofunction:: raytracing.Matrix.largestDiameter

--- a/docs/modules/methods/Matrix/raytracing.Matrix.traceManyThroughInParallelNoChunks.rst
+++ b/docs/modules/methods/Matrix/raytracing.Matrix.traceManyThroughInParallelNoChunks.rst
@@ -1,4 +1,0 @@
-Matrix.traceManyThroughInParallelNoChunks
-=========================================
-
-.. autofunction:: raytracing.Matrix.traceManyThroughInParallelNoChunks

--- a/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.ImagingPath.rst
+++ b/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.ImagingPath.rst
@@ -1,4 +1,0 @@
-MatrixGroup.ImagingPath
-=======================
-
-.. autofunction:: raytracing.MatrixGroup.ImagingPath

--- a/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.LaserPath.rst
+++ b/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.LaserPath.rst
@@ -1,4 +1,0 @@
-MatrixGroup.LaserPath
-=====================
-
-.. autofunction:: raytracing.MatrixGroup.LaserPath

--- a/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.insert.rst
+++ b/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.insert.rst
@@ -1,0 +1,4 @@
+MatrixGroup.insert
+==================
+
+.. autofunction:: raytracing.MatrixGroup.insert

--- a/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.largestDiameter.rst
+++ b/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.largestDiameter.rst
@@ -1,4 +1,0 @@
-MatrixGroup.largestDiameter
-===========================
-
-.. autofunction:: raytracing.MatrixGroup.largestDiameter

--- a/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.load.rst
+++ b/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.load.rst
@@ -1,0 +1,4 @@
+MatrixGroup.load
+================
+
+.. autofunction:: raytracing.MatrixGroup.load

--- a/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.pop.rst
+++ b/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.pop.rst
@@ -1,0 +1,4 @@
+MatrixGroup.pop
+===============
+
+.. autofunction:: raytracing.MatrixGroup.pop

--- a/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.save.rst
+++ b/docs/modules/methods/MatrixGroup/raytracing.MatrixGroup.save.rst
@@ -1,0 +1,4 @@
+MatrixGroup.save
+================
+
+.. autofunction:: raytracing.MatrixGroup.save

--- a/docs/modules/methods/Objective/raytracing.Objective.drawAperture.rst
+++ b/docs/modules/methods/Objective/raytracing.Objective.drawAperture.rst
@@ -1,4 +1,0 @@
-Objective.drawAperture
-======================
-
-.. autofunction:: raytracing.Objective.drawAperture

--- a/docs/modules/methods/Objective/raytracing.Objective.drawAt.rst
+++ b/docs/modules/methods/Objective/raytracing.Objective.drawAt.rst
@@ -1,4 +1,0 @@
-Objective.drawAt
-================
-
-.. autofunction:: raytracing.Objective.drawAt

--- a/docs/modules/methods/Space/raytracing.Space.drawAt.rst
+++ b/docs/modules/methods/Space/raytracing.Space.drawAt.rst
@@ -1,4 +1,0 @@
-Space.drawAt
-============
-
-.. autofunction:: raytracing.Space.drawAt

--- a/docs/modules/methods/ThickLens/raytracing.ThickLens.drawAperture.rst
+++ b/docs/modules/methods/ThickLens/raytracing.ThickLens.drawAperture.rst
@@ -1,4 +1,0 @@
-ThickLens.drawAperture
-======================
-
-.. autofunction:: raytracing.ThickLens.drawAperture

--- a/docs/modules/methods/ThickLens/raytracing.ThickLens.drawAt.rst
+++ b/docs/modules/methods/ThickLens/raytracing.ThickLens.drawAt.rst
@@ -1,4 +1,0 @@
-ThickLens.drawAt
-================
-
-.. autofunction:: raytracing.ThickLens.drawAt

--- a/docs/modules/raytracing.AchromatDoubletLens.rst
+++ b/docs/modules/raytracing.AchromatDoubletLens.rst
@@ -19,8 +19,6 @@ AchromatDoubletLens
 
     
         ~AchromatDoubletLens.__init__
-        ~AchromatDoubletLens.drawAperture
-        ~AchromatDoubletLens.drawAt
         ~AchromatDoubletLens.pointsOfInterest
 
 
@@ -36,4 +34,5 @@ AchromatDoubletLens
       ~AchromatDoubletLens.determinant
       ~AchromatDoubletLens.hasPower
       ~AchromatDoubletLens.isImaging
+      ~AchromatDoubletLens.largestDiameter
 

--- a/docs/modules/raytracing.Aperture.rst
+++ b/docs/modules/raytracing.Aperture.rst
@@ -19,7 +19,6 @@ Aperture
 
     
         ~Aperture.__init__
-        ~Aperture.drawAt
 
 
 
@@ -34,4 +33,5 @@ Aperture
       ~Aperture.determinant
       ~Aperture.hasPower
       ~Aperture.isImaging
+      ~Aperture.largestDiameter
 

--- a/docs/modules/raytracing.Axicon.rst
+++ b/docs/modules/raytracing.Axicon.rst
@@ -38,4 +38,5 @@ Axicon
       ~Axicon.determinant
       ~Axicon.hasPower
       ~Axicon.isImaging
+      ~Axicon.largestDiameter
 

--- a/docs/modules/raytracing.CurvedMirror.rst
+++ b/docs/modules/raytracing.CurvedMirror.rst
@@ -35,4 +35,5 @@ CurvedMirror
       ~CurvedMirror.determinant
       ~CurvedMirror.hasPower
       ~CurvedMirror.isImaging
+      ~CurvedMirror.largestDiameter
 

--- a/docs/modules/raytracing.DielectricInterface.rst
+++ b/docs/modules/raytracing.DielectricInterface.rst
@@ -19,7 +19,6 @@ DielectricInterface
 
     
         ~DielectricInterface.__init__
-        ~DielectricInterface.drawAt
         ~DielectricInterface.flipOrientation
 
 
@@ -35,4 +34,5 @@ DielectricInterface
       ~DielectricInterface.determinant
       ~DielectricInterface.hasPower
       ~DielectricInterface.isImaging
+      ~DielectricInterface.largestDiameter
 

--- a/docs/modules/raytracing.DielectricSlab.rst
+++ b/docs/modules/raytracing.DielectricSlab.rst
@@ -19,7 +19,6 @@ DielectricSlab
 
     
         ~DielectricSlab.__init__
-        ~DielectricSlab.drawAt
         ~DielectricSlab.transferMatrix
 
 
@@ -35,4 +34,5 @@ DielectricSlab
       ~DielectricSlab.determinant
       ~DielectricSlab.hasPower
       ~DielectricSlab.isImaging
+      ~DielectricSlab.largestDiameter
 

--- a/docs/modules/raytracing.ImagingPath.rst
+++ b/docs/modules/raytracing.ImagingPath.rst
@@ -20,27 +20,17 @@ ImagingPath
     
         ~ImagingPath.__init__
         ~ImagingPath.apertureStop
-        ~ImagingPath.axialRays
+        ~ImagingPath.axialRay
         ~ImagingPath.chiefRay
-        ~ImagingPath.createRayTracePlot
         ~ImagingPath.display
-        ~ImagingPath.displayRange
-        ~ImagingPath.drawDisplayObjects
-        ~ImagingPath.drawEntrancePupil
-        ~ImagingPath.drawImages
-        ~ImagingPath.drawObject
-        ~ImagingPath.drawOpticalElements
-        ~ImagingPath.drawRayTraces
-        ~ImagingPath.drawStops
         ~ImagingPath.entrancePupil
         ~ImagingPath.fieldOfView
         ~ImagingPath.fieldStop
         ~ImagingPath.imageSize
         ~ImagingPath.lagrangeInvariant
         ~ImagingPath.marginalRays
-        ~ImagingPath.rearrangeRayTraceForPlotting
+        ~ImagingPath.principalRay
         ~ImagingPath.save
-        ~ImagingPath.updateDisplay
 
 
 
@@ -55,4 +45,6 @@ ImagingPath
       ~ImagingPath.determinant
       ~ImagingPath.hasPower
       ~ImagingPath.isImaging
+      ~ImagingPath.largestDiameter
+      ~ImagingPath.objectHeight
 

--- a/docs/modules/raytracing.LambertianRays.rst
+++ b/docs/modules/raytracing.LambertianRays.rst
@@ -31,6 +31,7 @@ LambertianRays
 
     
       ~LambertianRays.count
+      ~LambertianRays.rays
       ~LambertianRays.thetaValues
       ~LambertianRays.yValues
 

--- a/docs/modules/raytracing.LaserPath.rst
+++ b/docs/modules/raytracing.LaserPath.rst
@@ -40,4 +40,5 @@ LaserPath
       ~LaserPath.determinant
       ~LaserPath.hasPower
       ~LaserPath.isImaging
+      ~LaserPath.largestDiameter
 

--- a/docs/modules/raytracing.Lens.rst
+++ b/docs/modules/raytracing.Lens.rst
@@ -19,7 +19,6 @@ Lens
 
     
         ~Lens.__init__
-        ~Lens.drawAt
         ~Lens.pointsOfInterest
 
 
@@ -35,4 +34,5 @@ Lens
       ~Lens.determinant
       ~Lens.hasPower
       ~Lens.isImaging
+      ~Lens.largestDiameter
 

--- a/docs/modules/raytracing.Matrix.rst
+++ b/docs/modules/raytracing.Matrix.rst
@@ -19,18 +19,9 @@ Matrix
 
     
         ~Matrix.__init__
-        ~Matrix.axesToDataScale
         ~Matrix.backFocalLength
         ~Matrix.backwardConjugate
-        ~Matrix.display
         ~Matrix.displayHalfHeight
-        ~Matrix.drawAperture
-        ~Matrix.drawAt
-        ~Matrix.drawCardinalPoints
-        ~Matrix.drawLabels
-        ~Matrix.drawPointsOfInterest
-        ~Matrix.drawPrincipalPlanes
-        ~Matrix.drawVertices
         ~Matrix.effectiveFocalLengths
         ~Matrix.flipOrientation
         ~Matrix.focalDistances
@@ -39,7 +30,6 @@ Matrix
         ~Matrix.frontFocalLength
         ~Matrix.hasFiniteApertureDiameter
         ~Matrix.lagrangeInvariant
-        ~Matrix.largestDiameter
         ~Matrix.magnification
         ~Matrix.mul_beam
         ~Matrix.mul_matrix
@@ -50,7 +40,6 @@ Matrix
         ~Matrix.traceMany
         ~Matrix.traceManyThrough
         ~Matrix.traceManyThroughInParallel
-        ~Matrix.traceManyThroughInParallelNoChunks
         ~Matrix.traceThrough
         ~Matrix.transferMatrices
         ~Matrix.transferMatrix
@@ -68,4 +57,5 @@ Matrix
       ~Matrix.determinant
       ~Matrix.hasPower
       ~Matrix.isImaging
+      ~Matrix.largestDiameter
 

--- a/docs/modules/raytracing.MatrixGroup.rst
+++ b/docs/modules/raytracing.MatrixGroup.rst
@@ -18,16 +18,17 @@ MatrixGroup
     :toctree: methods/MatrixGroup
 
     
-        ~MatrixGroup.ImagingPath
-        ~MatrixGroup.LaserPath
         ~MatrixGroup.__init__
         ~MatrixGroup.append
         ~MatrixGroup.drawAt
         ~MatrixGroup.drawPointsOfInterest
         ~MatrixGroup.flipOrientation
         ~MatrixGroup.hasFiniteApertureDiameter
+        ~MatrixGroup.insert
         ~MatrixGroup.intermediateConjugates
-        ~MatrixGroup.largestDiameter
+        ~MatrixGroup.load
+        ~MatrixGroup.pop
+        ~MatrixGroup.save
         ~MatrixGroup.trace
         ~MatrixGroup.transferMatrices
         ~MatrixGroup.transferMatrix
@@ -45,4 +46,5 @@ MatrixGroup
       ~MatrixGroup.determinant
       ~MatrixGroup.hasPower
       ~MatrixGroup.isImaging
+      ~MatrixGroup.largestDiameter
 

--- a/docs/modules/raytracing.Objective.rst
+++ b/docs/modules/raytracing.Objective.rst
@@ -19,8 +19,6 @@ Objective
 
     
         ~Objective.__init__
-        ~Objective.drawAperture
-        ~Objective.drawAt
         ~Objective.flipOrientation
         ~Objective.pointsOfInterest
 
@@ -37,5 +35,6 @@ Objective
       ~Objective.determinant
       ~Objective.hasPower
       ~Objective.isImaging
+      ~Objective.largestDiameter
       ~Objective.warningDisplayed
 

--- a/docs/modules/raytracing.RandomLambertianRays.rst
+++ b/docs/modules/raytracing.RandomLambertianRays.rst
@@ -32,6 +32,7 @@ RandomLambertianRays
 
     
       ~RandomLambertianRays.count
+      ~RandomLambertianRays.rays
       ~RandomLambertianRays.thetaValues
       ~RandomLambertianRays.yValues
 

--- a/docs/modules/raytracing.RandomRays.rst
+++ b/docs/modules/raytracing.RandomRays.rst
@@ -32,6 +32,7 @@ RandomRays
 
     
       ~RandomRays.count
+      ~RandomRays.rays
       ~RandomRays.thetaValues
       ~RandomRays.yValues
 

--- a/docs/modules/raytracing.RandomUniformRays.rst
+++ b/docs/modules/raytracing.RandomUniformRays.rst
@@ -32,6 +32,7 @@ RandomUniformRays
 
     
       ~RandomUniformRays.count
+      ~RandomUniformRays.rays
       ~RandomUniformRays.thetaValues
       ~RandomUniformRays.yValues
 

--- a/docs/modules/raytracing.Rays.rst
+++ b/docs/modules/raytracing.Rays.rst
@@ -38,6 +38,7 @@ Rays
 
     
       ~Rays.count
+      ~Rays.rays
       ~Rays.thetaValues
       ~Rays.yValues
 

--- a/docs/modules/raytracing.Space.rst
+++ b/docs/modules/raytracing.Space.rst
@@ -19,7 +19,6 @@ Space
 
     
         ~Space.__init__
-        ~Space.drawAt
         ~Space.transferMatrix
 
 
@@ -35,4 +34,5 @@ Space
       ~Space.determinant
       ~Space.hasPower
       ~Space.isImaging
+      ~Space.largestDiameter
 

--- a/docs/modules/raytracing.System2f.rst
+++ b/docs/modules/raytracing.System2f.rst
@@ -33,4 +33,5 @@ System2f
       ~System2f.determinant
       ~System2f.hasPower
       ~System2f.isImaging
+      ~System2f.largestDiameter
 

--- a/docs/modules/raytracing.System4f.rst
+++ b/docs/modules/raytracing.System4f.rst
@@ -33,4 +33,5 @@ System4f
       ~System4f.determinant
       ~System4f.hasPower
       ~System4f.isImaging
+      ~System4f.largestDiameter
 

--- a/docs/modules/raytracing.ThickLens.rst
+++ b/docs/modules/raytracing.ThickLens.rst
@@ -19,8 +19,6 @@ ThickLens
 
     
         ~ThickLens.__init__
-        ~ThickLens.drawAperture
-        ~ThickLens.drawAt
         ~ThickLens.flipOrientation
         ~ThickLens.pointsOfInterest
         ~ThickLens.transferMatrix
@@ -38,4 +36,5 @@ ThickLens
       ~ThickLens.determinant
       ~ThickLens.hasPower
       ~ThickLens.isImaging
+      ~ThickLens.largestDiameter
 

--- a/docs/modules/raytracing.UniformRays.rst
+++ b/docs/modules/raytracing.UniformRays.rst
@@ -31,6 +31,7 @@ UniformRays
 
     
       ~UniformRays.count
+      ~UniformRays.rays
       ~UniformRays.thetaValues
       ~UniformRays.yValues
 

--- a/docs/modules/raytracing.eo.PN_33_921.rst
+++ b/docs/modules/raytracing.eo.PN_33_921.rst
@@ -33,4 +33,5 @@ PN\_33\_921
       ~PN_33_921.determinant
       ~PN_33_921.hasPower
       ~PN_33_921.isImaging
+      ~PN_33_921.largestDiameter
 

--- a/docs/modules/raytracing.eo.PN_33_922.rst
+++ b/docs/modules/raytracing.eo.PN_33_922.rst
@@ -33,4 +33,5 @@ PN\_33\_922
       ~PN_33_922.determinant
       ~PN_33_922.hasPower
       ~PN_33_922.isImaging
+      ~PN_33_922.largestDiameter
 

--- a/docs/modules/raytracing.eo.PN_85_877.rst
+++ b/docs/modules/raytracing.eo.PN_85_877.rst
@@ -33,4 +33,5 @@ PN\_85\_877
       ~PN_85_877.determinant
       ~PN_85_877.hasPower
       ~PN_85_877.isImaging
+      ~PN_85_877.largestDiameter
 

--- a/docs/modules/raytracing.eo.PN_88_593.rst
+++ b/docs/modules/raytracing.eo.PN_88_593.rst
@@ -33,4 +33,5 @@ PN\_88\_593
       ~PN_88_593.determinant
       ~PN_88_593.hasPower
       ~PN_88_593.isImaging
+      ~PN_88_593.largestDiameter
 

--- a/docs/modules/raytracing.nikon.LWD16X.rst
+++ b/docs/modules/raytracing.nikon.LWD16X.rst
@@ -33,5 +33,6 @@ LWD16X
       ~LWD16X.determinant
       ~LWD16X.hasPower
       ~LWD16X.isImaging
+      ~LWD16X.largestDiameter
       ~LWD16X.warningDisplayed
 

--- a/docs/modules/raytracing.olympus.LUMPlanFL40X.rst
+++ b/docs/modules/raytracing.olympus.LUMPlanFL40X.rst
@@ -33,5 +33,6 @@ LUMPlanFL40X
       ~LUMPlanFL40X.determinant
       ~LUMPlanFL40X.hasPower
       ~LUMPlanFL40X.isImaging
+      ~LUMPlanFL40X.largestDiameter
       ~LUMPlanFL40X.warningDisplayed
 

--- a/docs/modules/raytracing.olympus.MVPlapo2XC.rst
+++ b/docs/modules/raytracing.olympus.MVPlapo2XC.rst
@@ -33,5 +33,6 @@ MVPlapo2XC
       ~MVPlapo2XC.determinant
       ~MVPlapo2XC.hasPower
       ~MVPlapo2XC.isImaging
+      ~MVPlapo2XC.largestDiameter
       ~MVPlapo2XC.warningDisplayed
 

--- a/docs/modules/raytracing.olympus.UMPLFN20XW.rst
+++ b/docs/modules/raytracing.olympus.UMPLFN20XW.rst
@@ -33,5 +33,6 @@ UMPLFN20XW
       ~UMPLFN20XW.determinant
       ~UMPLFN20XW.hasPower
       ~UMPLFN20XW.isImaging
+      ~UMPLFN20XW.largestDiameter
       ~UMPLFN20XW.warningDisplayed
 

--- a/docs/modules/raytracing.olympus.XLPLN25X.rst
+++ b/docs/modules/raytracing.olympus.XLPLN25X.rst
@@ -33,5 +33,6 @@ XLPLN25X
       ~XLPLN25X.determinant
       ~XLPLN25X.hasPower
       ~XLPLN25X.isImaging
+      ~XLPLN25X.largestDiameter
       ~XLPLN25X.warningDisplayed
 

--- a/docs/modules/raytracing.olympus.XLUMPlanFLN20X.rst
+++ b/docs/modules/raytracing.olympus.XLUMPlanFLN20X.rst
@@ -33,5 +33,6 @@ XLUMPlanFLN20X
       ~XLUMPlanFLN20X.determinant
       ~XLUMPlanFLN20X.hasPower
       ~XLUMPlanFLN20X.isImaging
+      ~XLUMPlanFLN20X.largestDiameter
       ~XLUMPlanFLN20X.warningDisplayed
 

--- a/docs/modules/raytracing.thorlabs.AC254_030_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_030_A.rst
@@ -33,4 +33,5 @@ AC254\_030\_A
       ~AC254_030_A.determinant
       ~AC254_030_A.hasPower
       ~AC254_030_A.isImaging
+      ~AC254_030_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_035_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_035_A.rst
@@ -33,4 +33,5 @@ AC254\_035\_A
       ~AC254_035_A.determinant
       ~AC254_035_A.hasPower
       ~AC254_035_A.isImaging
+      ~AC254_035_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_040_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_040_A.rst
@@ -33,4 +33,5 @@ AC254\_040\_A
       ~AC254_040_A.determinant
       ~AC254_040_A.hasPower
       ~AC254_040_A.isImaging
+      ~AC254_040_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_045_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_045_A.rst
@@ -33,4 +33,5 @@ AC254\_045\_A
       ~AC254_045_A.determinant
       ~AC254_045_A.hasPower
       ~AC254_045_A.isImaging
+      ~AC254_045_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_050_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_050_A.rst
@@ -33,4 +33,5 @@ AC254\_050\_A
       ~AC254_050_A.determinant
       ~AC254_050_A.hasPower
       ~AC254_050_A.isImaging
+      ~AC254_050_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_050_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_050_B.rst
@@ -33,4 +33,5 @@ AC254\_050\_B
       ~AC254_050_B.determinant
       ~AC254_050_B.hasPower
       ~AC254_050_B.isImaging
+      ~AC254_050_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_060_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_060_A.rst
@@ -33,4 +33,5 @@ AC254\_060\_A
       ~AC254_060_A.determinant
       ~AC254_060_A.hasPower
       ~AC254_060_A.isImaging
+      ~AC254_060_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_075_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_075_A.rst
@@ -33,4 +33,5 @@ AC254\_075\_A
       ~AC254_075_A.determinant
       ~AC254_075_A.hasPower
       ~AC254_075_A.isImaging
+      ~AC254_075_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_080_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_080_A.rst
@@ -33,4 +33,5 @@ AC254\_080\_A
       ~AC254_080_A.determinant
       ~AC254_080_A.hasPower
       ~AC254_080_A.isImaging
+      ~AC254_080_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_100_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_100_A.rst
@@ -33,4 +33,5 @@ AC254\_100\_A
       ~AC254_100_A.determinant
       ~AC254_100_A.hasPower
       ~AC254_100_A.isImaging
+      ~AC254_100_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_125_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_125_A.rst
@@ -33,4 +33,5 @@ AC254\_125\_A
       ~AC254_125_A.determinant
       ~AC254_125_A.hasPower
       ~AC254_125_A.isImaging
+      ~AC254_125_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_150_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_150_A.rst
@@ -33,4 +33,5 @@ AC254\_150\_A
       ~AC254_150_A.determinant
       ~AC254_150_A.hasPower
       ~AC254_150_A.isImaging
+      ~AC254_150_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_200_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_200_A.rst
@@ -33,4 +33,5 @@ AC254\_200\_A
       ~AC254_200_A.determinant
       ~AC254_200_A.hasPower
       ~AC254_200_A.isImaging
+      ~AC254_200_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_250_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_250_A.rst
@@ -33,4 +33,5 @@ AC254\_250\_A
       ~AC254_250_A.determinant
       ~AC254_250_A.hasPower
       ~AC254_250_A.isImaging
+      ~AC254_250_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_300_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_300_A.rst
@@ -33,4 +33,5 @@ AC254\_300\_A
       ~AC254_300_A.determinant
       ~AC254_300_A.hasPower
       ~AC254_300_A.isImaging
+      ~AC254_300_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_400_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_400_A.rst
@@ -33,4 +33,5 @@ AC254\_400\_A
       ~AC254_400_A.determinant
       ~AC254_400_A.hasPower
       ~AC254_400_A.isImaging
+      ~AC254_400_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC254_500_A.rst
+++ b/docs/modules/raytracing.thorlabs.AC254_500_A.rst
@@ -33,4 +33,5 @@ AC254\_500\_A
       ~AC254_500_A.determinant
       ~AC254_500_A.hasPower
       ~AC254_500_A.isImaging
+      ~AC254_500_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_075_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_075_B.rst
@@ -33,4 +33,5 @@ AC508\_075\_B
       ~AC508_075_B.determinant
       ~AC508_075_B.hasPower
       ~AC508_075_B.isImaging
+      ~AC508_075_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_080_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_080_B.rst
@@ -33,4 +33,5 @@ AC508\_080\_B
       ~AC508_080_B.determinant
       ~AC508_080_B.hasPower
       ~AC508_080_B.isImaging
+      ~AC508_080_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_1000_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_1000_B.rst
@@ -33,4 +33,5 @@ AC508\_1000\_B
       ~AC508_1000_B.determinant
       ~AC508_1000_B.hasPower
       ~AC508_1000_B.isImaging
+      ~AC508_1000_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_100_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_100_B.rst
@@ -33,4 +33,5 @@ AC508\_100\_B
       ~AC508_100_B.determinant
       ~AC508_100_B.hasPower
       ~AC508_100_B.isImaging
+      ~AC508_100_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_150_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_150_B.rst
@@ -33,4 +33,5 @@ AC508\_150\_B
       ~AC508_150_B.determinant
       ~AC508_150_B.hasPower
       ~AC508_150_B.isImaging
+      ~AC508_150_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_200_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_200_B.rst
@@ -33,4 +33,5 @@ AC508\_200\_B
       ~AC508_200_B.determinant
       ~AC508_200_B.hasPower
       ~AC508_200_B.isImaging
+      ~AC508_200_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_250_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_250_B.rst
@@ -33,4 +33,5 @@ AC508\_250\_B
       ~AC508_250_B.determinant
       ~AC508_250_B.hasPower
       ~AC508_250_B.isImaging
+      ~AC508_250_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_300_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_300_B.rst
@@ -33,4 +33,5 @@ AC508\_300\_B
       ~AC508_300_B.determinant
       ~AC508_300_B.hasPower
       ~AC508_300_B.isImaging
+      ~AC508_300_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_400_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_400_B.rst
@@ -33,4 +33,5 @@ AC508\_400\_B
       ~AC508_400_B.determinant
       ~AC508_400_B.hasPower
       ~AC508_400_B.isImaging
+      ~AC508_400_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_500_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_500_B.rst
@@ -33,4 +33,5 @@ AC508\_500\_B
       ~AC508_500_B.determinant
       ~AC508_500_B.hasPower
       ~AC508_500_B.isImaging
+      ~AC508_500_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.AC508_750_B.rst
+++ b/docs/modules/raytracing.thorlabs.AC508_750_B.rst
@@ -33,4 +33,5 @@ AC508\_750\_B
       ~AC508_750_B.determinant
       ~AC508_750_B.hasPower
       ~AC508_750_B.isImaging
+      ~AC508_750_B.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.ACN254_040_A.rst
+++ b/docs/modules/raytracing.thorlabs.ACN254_040_A.rst
@@ -33,4 +33,5 @@ ACN254\_040\_A
       ~ACN254_040_A.determinant
       ~ACN254_040_A.hasPower
       ~ACN254_040_A.isImaging
+      ~ACN254_040_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.ACN254_050_A.rst
+++ b/docs/modules/raytracing.thorlabs.ACN254_050_A.rst
@@ -33,4 +33,5 @@ ACN254\_050\_A
       ~ACN254_050_A.determinant
       ~ACN254_050_A.hasPower
       ~ACN254_050_A.isImaging
+      ~ACN254_050_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.ACN254_075_A.rst
+++ b/docs/modules/raytracing.thorlabs.ACN254_075_A.rst
@@ -33,4 +33,5 @@ ACN254\_075\_A
       ~ACN254_075_A.determinant
       ~ACN254_075_A.hasPower
       ~ACN254_075_A.isImaging
+      ~ACN254_075_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.ACN254_100_A.rst
+++ b/docs/modules/raytracing.thorlabs.ACN254_100_A.rst
@@ -33,4 +33,5 @@ ACN254\_100\_A
       ~ACN254_100_A.determinant
       ~ACN254_100_A.hasPower
       ~ACN254_100_A.isImaging
+      ~ACN254_100_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.LA1131_A.rst
+++ b/docs/modules/raytracing.thorlabs.LA1131_A.rst
@@ -33,4 +33,5 @@ LA1131\_A
       ~LA1131_A.determinant
       ~LA1131_A.hasPower
       ~LA1131_A.isImaging
+      ~LA1131_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.LA1134_A.rst
+++ b/docs/modules/raytracing.thorlabs.LA1134_A.rst
@@ -33,4 +33,5 @@ LA1134\_A
       ~LA1134_A.determinant
       ~LA1134_A.hasPower
       ~LA1134_A.isImaging
+      ~LA1134_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.LA1274_A.rst
+++ b/docs/modules/raytracing.thorlabs.LA1274_A.rst
@@ -33,4 +33,5 @@ LA1274\_A
       ~LA1274_A.determinant
       ~LA1274_A.hasPower
       ~LA1274_A.isImaging
+      ~LA1274_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.LA1422_A.rst
+++ b/docs/modules/raytracing.thorlabs.LA1422_A.rst
@@ -33,4 +33,5 @@ LA1422\_A
       ~LA1422_A.determinant
       ~LA1422_A.hasPower
       ~LA1422_A.isImaging
+      ~LA1422_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.LA1608_A.rst
+++ b/docs/modules/raytracing.thorlabs.LA1608_A.rst
@@ -33,4 +33,5 @@ LA1608\_A
       ~LA1608_A.determinant
       ~LA1608_A.hasPower
       ~LA1608_A.isImaging
+      ~LA1608_A.largestDiameter
 

--- a/docs/modules/raytracing.thorlabs.LA1805_A.rst
+++ b/docs/modules/raytracing.thorlabs.LA1805_A.rst
@@ -33,4 +33,5 @@ LA1805\_A
       ~LA1805_A.determinant
       ~LA1805_A.hasPower
       ~LA1805_A.isImaging
+      ~LA1805_A.largestDiameter
 


### PR DESCRIPTION
Fixes #268 
The stub files of the documentation (all small .rst files in raytracing/docs/modules) are not regenerated by ReadTheDocs... and I have yet to find a way. For now it's still refreshed by hand by deleting the stub files and typing sphinx-autogen -t docs/_templates docs/reference.rst in a console. 