### PR TITLE
Matrix product has the right indices

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -137,6 +137,10 @@ class Matrix(object):
         super(Matrix, self).__init__()
 
     @property
+    def isIdentity(self):
+        return self.A == 1 and self.D == 1 and self.B == 0 and self.C == 0
+
+    @property
     def determinant(self):
         """The determinant of the ABCD matrix is always frontIndex/backIndex,
         which is often 1.0
@@ -269,8 +273,17 @@ class Matrix(object):
         else:
             bv = rightSideMatrix.backVertex
 
-        return Matrix(a, b, c, d, frontVertex=fv, backVertex=bv, physicalLength=L,
-                      frontIndex=rightSideMatrix.frontIndex, backIndex=self.backIndex)
+        if self.isIdentity:  # If LHS is identity, take the other's indices
+            fIndex = rightSideMatrix.frontIndex
+            bIndex = rightSideMatrix.backIndex
+        elif rightSideMatrix.isIdentity:  # If RHS is identity, take other's indices
+            fIndex = self.frontIndex
+            bIndex = self.backIndex
+        else:  # Else, take the "first one" front index and the "last one" back index (physical first and last)
+            fIndex = rightSideMatrix.frontIndex
+            bIndex = self.backIndex
+
+        return Matrix(a, b, c, d, frontVertex=fv, backVertex=bv, physicalLength=L, frontIndex=fIndex, backIndex=bIndex)
 
     def mul_ray(self, rightSideRay):
         r"""This function does the multiplication of a ray by a matrix.

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -269,8 +269,8 @@ class Matrix(object):
         else:
             bv = rightSideMatrix.backVertex
 
-        return Matrix(a, b, c, d, frontVertex=fv, backVertex=bv, physicalLength=L, frontIndex=self.frontIndex,
-                      backIndex=rightSideMatrix.backIndex)
+        return Matrix(a, b, c, d, frontVertex=fv, backVertex=bv, physicalLength=L,
+                      frontIndex=rightSideMatrix.frontIndex, backIndex=self.backIndex)
 
     def mul_ray(self, rightSideRay):
         r"""This function does the multiplication of a ray by a matrix.

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -181,7 +181,7 @@ class Matrix(object):
                 "Unrecognized right side element in multiply: '{0}'\
                  cannot be multiplied by a Matrix".format(rightSide))
 
-    def mul_matrix(self, rightSideMatrix):
+    def mul_matrix(self, rightSideMatrix: 'Matrix'):
         r""" This function is used to combine two elements into a single matrix.
         The multiplication of two ABCD matrices calculates the total ABCD matrix of the system.
         Total length of the elements is calculated (z) but apertures are lost. We compute
@@ -269,7 +269,8 @@ class Matrix(object):
         else:
             bv = rightSideMatrix.backVertex
 
-        return Matrix(a, b, c, d, frontVertex=fv, backVertex=bv, physicalLength=L)
+        return Matrix(a, b, c, d, frontVertex=fv, backVertex=bv, physicalLength=L, frontIndex=self.frontIndex,
+                      backIndex=rightSideMatrix.backIndex)
 
     def mul_ray(self, rightSideRay):
         r"""This function does the multiplication of a ray by a matrix.
@@ -1547,7 +1548,7 @@ class Space(Matrix):
         """
         distance = upTo
         if distance < self.L:
-            return Space(distance)
+            return Space(distance, self.frontIndex)
         else:
             return self
 

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -36,6 +36,20 @@ class TestMatrix(envtest.RaytracingTestCase):
         self.assertEqual(m3.C, 1 * 7 + 3 * 8)
         self.assertEqual(m3.D, 2 * 7 + 4 * 8)
 
+    def testMatrixProductIndicesBoth1(self):
+        m1 = Matrix()
+        m2 = Matrix()
+        m3 = m1 * m2
+        self.assertEqual(m3.frontIndex, 1)
+        self.assertEqual(m3.backIndex, 1)
+
+    def testMatrixProductIndicesNot1(self):
+        m1 = Matrix(frontIndex=1.33)
+        m2 = Matrix(backIndex=1.5)
+        m3 = m1 * m2
+        self.assertEqual(m3.frontIndex, 1.33)
+        self.assertEqual(m3.backIndex, 1.5)
+
     def testMatrixProductWithRayMath(self):
         m1 = Matrix(A=1, B=2, C=3, D=4)
         rayIn = Ray(y=1, theta=0.1)

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -36,6 +36,14 @@ class TestMatrix(envtest.RaytracingTestCase):
         self.assertEqual(m3.C, 1 * 7 + 3 * 8)
         self.assertEqual(m3.D, 2 * 7 + 4 * 8)
 
+    def testIsIdentity(self):
+        m = Matrix()
+        self.assertTrue(m.isIdentity)
+
+    def testIsNotIdentity(self):
+        m = Matrix(1, 2, 0, 1)
+        self.assertFalse(m.isIdentity)
+
     def testMatrixProductIndicesBoth1(self):
         m1 = Matrix()
         m2 = Matrix()
@@ -43,12 +51,26 @@ class TestMatrix(envtest.RaytracingTestCase):
         self.assertEqual(m3.frontIndex, 1)
         self.assertEqual(m3.backIndex, 1)
 
-    def testMatrixProductIndicesNot1(self):
+    def testMatrixProductIndicesLHSIsIdentity(self):
         m1 = Matrix(backIndex=1.33)
-        m2 = Matrix(frontIndex=1.5)
+        m2 = Matrix(1, 10, 0, 1, frontIndex=1.5, backIndex=1.5)
         m3 = m1 * m2
         self.assertEqual(m3.frontIndex, 1.5)
-        self.assertEqual(m3.backIndex, 1.33)
+        self.assertEqual(m3.backIndex, 1.5)
+
+    def testMatrixProductIndicesRHSIsIdentity(self):
+        m1 = Matrix(backIndex=1.33)
+        m2 = Matrix(1, 10, 0, 1, frontIndex=1.5, backIndex=1.5)
+        m3 = m2 * m1
+        self.assertEqual(m3.frontIndex, 1.5)
+        self.assertEqual(m3.backIndex, 1.5)
+
+    def testMatrixProductIndicesNoIdentity(self):
+        m1 = Matrix(1, 10, 0, 1, backIndex=1.33, frontIndex=1)
+        m2 = Matrix(1, 10, 0, 1, backIndex=1, frontIndex=1.33)
+        m3 = m2 * m1
+        self.assertEqual(m3.frontIndex, 1)
+        self.assertEqual(m3.backIndex, 1)
 
     def testMatrixProductWithRayMath(self):
         m1 = Matrix(A=1, B=2, C=3, D=4)
@@ -337,7 +359,8 @@ class TestMatrix(envtest.RaytracingTestCase):
         # One less ray, because last is blocked
         self.assertEqual(len(traceManyThrough), len(rays) - 1)
 
-    @envtest.skipIf(sys.platform == 'darwin' and sys.version_info.major == 3 and sys.version_info.minor <= 7,"Endless loop on macOS")
+    @envtest.skipIf(sys.platform == 'darwin' and sys.version_info.major == 3 and sys.version_info.minor <= 7,
+                    "Endless loop on macOS")
     # Some information here: https://github.com/gammapy/gammapy/issues/2453
     def testTraceManyThroughInParallel(self):
         rays = [Ray(y, y) for y in range(5)]
@@ -350,7 +373,8 @@ class TestMatrix(envtest.RaytracingTestCase):
         except:
             pass
 
-    @envtest.skipIf(sys.platform == 'darwin' and sys.version_info.major == 3 and sys.version_info.minor <= 7,"Endless loop on macOS")
+    @envtest.skipIf(sys.platform == 'darwin' and sys.version_info.major == 3 and sys.version_info.minor <= 7,
+                    "Endless loop on macOS")
     # Some information here: https://github.com/gammapy/gammapy/issues/2453
     def testTraceManyThroughInParallel(self):
         rays = [Ray(y, y) for y in range(5)]

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -44,11 +44,11 @@ class TestMatrix(envtest.RaytracingTestCase):
         self.assertEqual(m3.backIndex, 1)
 
     def testMatrixProductIndicesNot1(self):
-        m1 = Matrix(frontIndex=1.33)
-        m2 = Matrix(backIndex=1.5)
+        m1 = Matrix(backIndex=1.33)
+        m2 = Matrix(frontIndex=1.5)
         m3 = m1 * m2
-        self.assertEqual(m3.frontIndex, 1.33)
-        self.assertEqual(m3.backIndex, 1.5)
+        self.assertEqual(m3.frontIndex, 1.5)
+        self.assertEqual(m3.backIndex, 1.33)
 
     def testMatrixProductWithRayMath(self):
         m1 = Matrix(A=1, B=2, C=3, D=4)


### PR DESCRIPTION
I modified `mul_matrix` to consider the indices of refraction of the two matrices for the product. We were returning a matrix with the right ABCD and vertices, but the indices were kept at 1 (default value). Now, we have (when both matrices are not identity matrices):
- Front index is the front index of the left hand side of the product (i.e. `self`)
- Back index is the back index of the right hand side of the product

If RHS is identity:
- Front and back indices are the same as LHS

If LHS is identity:
- Front and back indices are the same as RHS

I made it this way, because identity matrices (such as apertures or "the first transfer matrix" in `transferMatrix`) are not supposed to affect the indices of refraction. They are just there to add a finite diameter or to be a neutral element.

We don't check for any mismatch because I think we need to keep this method as general as possible.

Fixes #272 