### PR TITLE
Matrix equality

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1362,6 +1362,11 @@ class Matrix(object):
             description += "\nf = +inf (afocal)\n"
         return description
 
+    def __eq__(self, other):
+        if isinstance(other, Matrix):
+            return self.__dict__ == other.__dict__
+        return False
+
 
 class Lens(Matrix):
     r"""A thin lens of focal f, null thickness and infinite or finite diameter

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -563,6 +563,33 @@ class TestMatrix(envtest.RaytracingTestCase):
         self.assertEqual(m.displayHalfHeight(), 4)
         self.assertEqual(m.displayHalfHeight(6), 6)
 
+    def testEqualityNotSameClassInstance(self):
+        m = Matrix()
+        self.assertNotEqual(m, 10)
+        self.assertNotEqual(m, Ray())
+        self.assertNotEqual(m, "Trust me, this is a Matrix. This is equal to Matrix()")
+
+    def testEqualityMatricesNotEqualSameABCD(self):
+        m = Matrix()
+        m2 = Matrix(frontIndex=10)
+        self.assertNotEqual(m, m2)
+
+    def testEqualityMatricesNotEqualDifferentABCD(self):
+        m = Matrix()
+        m2 = Matrix(A=1 / 2, D=2)
+        self.assertNotEqual(m, m2)
+
+    def testEqualityMatricesAreEqual(self):
+        m = Matrix()
+        m2 = Matrix()
+        self.assertEqual(m, m2)
+
+    def testEqualityMatrixAndSpaceEqual(self):
+        d = 10
+        m = Matrix(B=d, physicalLength=d)
+        space = Space(d)
+        self.assertEqual(m, space)
+
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsMatrixGroup.py
+++ b/raytracing/tests/testsMatrixGroup.py
@@ -106,11 +106,9 @@ class TestMatrixGroup(envtest.RaytracingTestCase):
         otherElement = Space(10)
         mg.append(otherElement)
         transferMat = otherElement * element
-        msg = "If this fails, it is because the appended object is copied or it is not the right object: it is not" \
-              "the same instance. At the time this test was written, the original object is appended." \
-              "It is a short way to check if it is the right one at the end of the list."
         self.assertEqual(len(mg.elements), 2)
-        self.assertIs(mg.elements[-1], otherElement, msg=msg)
+        self.assertEqual(mg.elements[-1], otherElement)
+        self.assertEqual(mg.elements[-1], otherElement)
         self.assertEqual(mg.L, transferMat.L)
         self.assertEqual(mg.A, transferMat.A)
         self.assertEqual(mg.B, transferMat.B)
@@ -187,28 +185,20 @@ class TestMatrixGroup(envtest.RaytracingTestCase):
         self.assertListEqual(mg.transferMatrices(), [])
 
     def testTransferMatricesOneElement(self):
-        msg = "The equality of matrices is based upon their id. It was sufficient when writing this test, because" \
-              "the matrix was not copied or changed: it was the 'whole' object that was appended (i.e. the original " \
-              "object and the appended object is the same object, same memory spot). If this fails, either" \
-              "they are not the same object anymore (but can still be 'equal') or they are purely different."
         element1 = Space(10)
         mg = MatrixGroup([element1])
         transferMatrices = mg.transferMatrices()
         self.assertEqual(len(transferMatrices), 1)
-        self.assertListEqual(transferMatrices, [element1], msg=msg)
+        self.assertListEqual(transferMatrices, [element1])
 
-    def transferMatrixTwoElements(self):
-        msg = "The equality of matrices is based upon their id. It was sufficient when writing this test, because" \
-              "the matrix was not copied or changed: it was the 'whole' object that was appended (i.e. the original " \
-              "object and the appended object is the same object, same memory spot). If this fails, either" \
-              "they are not the same object anymore (but can still be 'equal') or they are purely different."
+    def testTransferMatrixTwoElements(self):
         element1 = Space(10)
         mg = MatrixGroup([element1])
         element2 = Lens(2)
         mg.append(element2)
         transferMatrices = mg.transferMatrices()
         self.assertEqual(len(transferMatrices), 2)
-        self.assertListEqual(transferMatrices, [element1, element2], msg=msg)
+        self.assertListEqual(transferMatrices, [element1, element2])
 
     def testTraceEmptyMatrixGroup(self):
         mg = MatrixGroup()
@@ -305,7 +295,7 @@ class TestMatrixGroup(envtest.RaytracingTestCase):
 
     def testFlipOrientationEmptyGroup(self):
         mg = MatrixGroup()
-        self.assertIs(mg.flipOrientation(), mg)
+        self.assertEqual(mg.flipOrientation(), mg)
 
     def testFlipOrientation_1(self):
         space = Space(10)

--- a/raytracing/tests/testsMatrixGroup.py
+++ b/raytracing/tests/testsMatrixGroup.py
@@ -520,6 +520,33 @@ class TestMatrixGroup(envtest.RaytracingTestCase):
         mg[0] = space
         self.assertListEqual(mg.elements, [space, lens, space])
 
+    def testEqualityDifferentClassInstance(self):
+        mg = MatrixGroup()
+        self.assertNotEqual(mg, Matrix())
+        self.assertNotEqual(mg, Ray())
+        self.assertNotEqual(mg, [Space(10), Lens(10), Space(10)])
+        self.assertNotEqual(mg, complex(10, 20.12))
+
+    def testEqualityDifferentListLength(self):
+        mg1 = MatrixGroup()
+        mg2 = MatrixGroup([Space(10)])
+        self.assertNotEqual(mg1, mg2)
+
+    def testEqualitySameLengthDifferentElements(self):
+        mg1 = MatrixGroup([Space(10), Lens(10), Space(10), Space(10), Lens(10), Space(10)])
+        mg2 = MatrixGroup([Space(20), Lens(20), Space(20), Space(20), Lens(20), Space(20)])
+        self.assertNotEqual(mg1, mg2)
+
+    def testEqualitySameGroup(self):
+        mg1 = MatrixGroup([Space(10), Lens(10), Space(10), Space(10), Lens(10), Space(10)])
+        mg2 = MatrixGroup([Space(10), Lens(10), Space(10), Space(10), Lens(10), Space(10)])
+        self.assertEqual(mg1, mg2)
+
+    def testEqualityGroupIs4f(self):
+        mg = MatrixGroup([Space(10), Lens(10), Space(10), Space(10), Lens(10), Space(10)])
+        system4f = System4f(10, 10)
+        self.assertEqual(mg, system4f)
+
 
 class TestSaveAndLoadMatrixGroup(envtest.RaytracingTestCase):
 


### PR DESCRIPTION
I overriden `__eq__` of `Matrix`. It was doing mostly what `is` does, so two *identical* matrices could be *different* because their id would be different. Example:
````python
space = Space(10)
space2 = Space(10)
print(space == space2)
````
printed `False` because `space is not space2`. It is a problem if we want to compare (equal or not) two matrices, two matrix groups, etc. But now, it prints `True`. The way I implemented it is very simple: I didn't compare *every* attribute manually, it would be a real pain and it would require every subclass of `Matrix` to implement its own `__eq__`, because some classes have new attributes. It is based on `__dict__`. Long story short, when using `__dict__` on an instance of a class, it gives a dictionary of every attribute (and its value) that defines a specific object. Consider the following example:
```python
class Test:
    def __init__(self, a):
        self.a = a
if __name__ == "__main__":
    t1 = Test(1)
    t2 = Test(2)
    print(t1.__dict__)
    print(t2.__dict__)
```
The output is:
````python
{'a': 1}
{'a': 2}
````  
Knowing that, we can simply write `__eq__` as follows:
```python
def __eq__(self, other):
    if isinstance(other, Matrix):
        return self.__dict__ == other.__dict__
    return False
```

It is useful if we want to compare two matrices which is done in some tests. They didn't fail, because I was aware that `__eq__` behaved like `is`, so I made sure that I used the same instance when comparing. For example:
````python
def testElements(self):
    space = Space(10)
    mg = MatrixGroup([space])
    self.assertListEqual(mg.elements, [space])
````
this works because I use the same specific object. Not being careful, I would have written:
````python
def testElements(self):
    mg = MatrixGroup([Space(10)])
    self.assertListEqual(mg.elements, [Space(10)])
````
this fails because the space in the group does not have the same id as the space in the second list of the assertion. With the new `__eq__`, we don't have to be that careful with what specific object is used in comparisons.