### PR TITLE
Fix display of demos

### DIFF
--- a/raytracing/__main__.py
+++ b/raytracing/__main__.py
@@ -393,7 +393,7 @@ if 18 in examples:
     path.append(Space(d=180))
     path.append(olympus.LUMPlanFL40X())
     path.append(Space(d=10))
-    path.display(inputBeam=GaussianBeam(w=0.001), comments="""
+    path.display(beams=[GaussianBeam(w=0.001)], comments="""
     path = LaserPath()
     path.label = "Demo #18: Laser beam and vendor lenses"
     path.append(Space(d=50))
@@ -410,20 +410,19 @@ if 18 in examples:
     path.display()""")
 if 19 in examples:
     cavity = LaserCavity(label="Laser cavity: round trip\nCalculated laser modes")
-    cavity.isResonator = True
     cavity.append(Space(d=160))
     cavity.append(DielectricSlab(thickness=100, n=1.8))
     cavity.append(Space(d=160))
-    cavity.append(CurvedMirror(R=400))
+    cavity.append(CurvedMirror(R=-400))
     cavity.append(Space(d=160))
     cavity.append(DielectricSlab(thickness=100, n=1.8))
     cavity.append(Space(d=160))
 
     # Calculate all self-replicating modes (i.e. eigenmodes)
     (q1, q2) = cavity.eigenModes()
-    print(q1, q2)
+    print(q1,q2)
 
-    # Obtain all physical (i.e. finite) self-replicating modes
+    # Obtain all physical modes (i.e. only finite eigenmodes)
     qs = cavity.laserModes()
     for q in qs:
         print(q)

--- a/raytracing/__main__.py
+++ b/raytracing/__main__.py
@@ -1,5 +1,6 @@
 from .imagingpath import *
 from .laserpath import *
+from .lasercavity import *
 
 from .specialtylenses import *
 from .axicon import *
@@ -408,7 +409,7 @@ if 18 in examples:
     path.append(Space(d=10))
     path.display()""")
 if 19 in examples:
-    cavity = LaserPath(label="Laser cavity: round trip\nCalculated laser modes")
+    cavity = LaserCavity(label="Laser cavity: round trip\nCalculated laser modes")
     cavity.isResonator = True
     cavity.append(Space(d=160))
     cavity.append(DielectricSlab(thickness=100, n=1.8))

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -1191,6 +1191,7 @@ class ApertureGraphic(MatrixGraphic):
 class MatrixGroupGraphic(MatrixGraphic):
     def __init__(self, matrixGroup: MatrixGroup):
         self.matrixGroup = matrixGroup
+        self._halfHeight = None
         super().__init__(matrixGroup)
 
     @property
@@ -1199,6 +1200,12 @@ class MatrixGroupGraphic(MatrixGraphic):
         for element in self.matrixGroup.elements:
             L += element.L
         return L
+
+    @property
+    def halfHeight(self):
+        if self._halfHeight is None:
+            self._halfHeight = self.displayHalfHeight()
+        return self._halfHeight
 
     def drawAt(self, z, axes, showLabels=True):
         """ Draw each element of this group """
@@ -1243,12 +1250,40 @@ class MatrixGroupGraphic(MatrixGraphic):
                     labels[zStr] = label
             zElement += element.L
 
-        halfHeight = self.matrixGroup.largestDiameter() / 2
+        halfHeight = self.matrixGroup.largestDiameter / 2
         for zStr, label in labels.items():
             z = float(zStr)
             axes.annotate(label, xy=(z, 0.0), xytext=(z, -halfHeight * 0.5),
                           xycoords='data', fontsize=12,
                           ha='center', va='bottom')
+
+    def display(self):
+        fig, axes = plt.subplots(figsize=(10, 7))
+        self.drawAt(0, axes, showLabels=True)
+        self.drawAperture(0, axes)
+        self.drawPointsOfInterest(0, axes)
+        self.drawVertices(0, axes)
+        self.drawCardinalPoints(0, axes)
+        self.drawPrincipalPlanes(0, axes)
+        axes.set_ylim(-self.halfHeight * 1.6, self.halfHeight * 1.6)
+        self._showPlot()
+
+    def _showPlot(self):  # pragma: no cover
+        # internal, do not use
+        try:
+            plt.plot()
+            if sys.platform.startswith('win'):
+                plt.show()
+            else:
+                plt.draw()
+                while True:
+                    if plt.get_fignums():
+                        plt.pause(0.001)
+                    else:
+                        break
+
+        except KeyboardInterrupt:
+            plt.close()
 
 
 class AchromatDoubletLensGraphic(MatrixGroupGraphic):

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -1476,6 +1476,8 @@ class Graphic:
 
         if type(element) is Lens:
             return LensGraphic(element)
+        if type(element) is ThickLens:
+            return ThickLensGraphic(element)
         if type(element) is Space:
             return SpaceGraphic(element)
         if type(element) is DielectricInterface:

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -1523,11 +1523,11 @@ class ObjectiveGraphic(MatrixGroupGraphic):
 
 class Graphic:
     def __new__(cls, element):
-        if type(element) is AchromatDoubletLens:
+        if type(element) is AchromatDoubletLens or issubclass(type(element), AchromatDoubletLens):
             return AchromatDoubletLensGraphic(element)
-        if type(element) is SingletLens:
+        if type(element) is SingletLens or issubclass(type(element), SingletLens):
             return SingletLensGraphic(element)
-        if issubclass(type(element), Objective):
+        if issubclass(type(element), Objective) or issubclass(type(element), Objective):
             return ObjectiveGraphic(element)
         if issubclass(type(element), MatrixGroup):
             return MatrixGroupGraphic(element)

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -137,7 +137,8 @@ class Figure:
         self.drawDisplayObjects()
 
         self.axes.callbacks.connect('ylim_changed', self.onZoomCallback)
-        self.axes.set_ylim([-self.displayRange() / 2 * 1.5, self.displayRange() / 2 * 1.5])
+        self.axes.set_xlim(0 - self.path.L * 0.05, self.path.L + self.path.L * 0.05)
+        self.axes.set_ylim([-self.displayRange() / 2 * 1.6, self.displayRange() / 2 * 1.6])
 
         if filepath is not None:
             self.figure.savefig(filepath, dpi=600)
@@ -160,7 +161,7 @@ class Figure:
 
         self.axes.callbacks.connect('ylim_changed', self.onZoomCallback)
         self.axes.set_xlim(0 - self.path.L * 0.05, self.path.L + self.path.L * 0.05)
-        self.axes.set_ylim([-self.displayRange() / 2 * 1.5, self.displayRange() / 2 * 1.5])
+        self.axes.set_ylim([-self.displayRange() / 2 * 1.6, self.displayRange() / 2 * 1.6])
 
         if filepath is not None:
             self.figure.savefig(filepath, dpi=600)
@@ -624,9 +625,8 @@ class Figure:
         yScale : float
             The scale of y axes
         """
-        # xScale, yScale = self.axes.viewLim.bounds[2:]
         xScale = self.path.L * 1.1
-        yScale = self.displayRange() * 1.5
+        yScale = self.displayRange() * 1.6
 
         return xScale, yScale
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -159,6 +159,7 @@ class Figure:
         self.drawDisplayObjects()
 
         self.axes.callbacks.connect('ylim_changed', self.onZoomCallback)
+        self.axes.set_xlim(0 - self.path.L * 0.05, self.path.L + self.path.L * 0.05)
         self.axes.set_ylim([-self.displayRange() / 2 * 1.5, self.displayRange() / 2 * 1.5])
 
         if filepath is not None:
@@ -623,8 +624,9 @@ class Figure:
         yScale : float
             The scale of y axes
         """
-
-        xScale, yScale = self.axes.viewLim.bounds[2:]
+        # xScale, yScale = self.axes.viewLim.bounds[2:]
+        xScale = self.path.L * 1.1
+        yScale = self.displayRange() * 1.5
 
         return xScale, yScale
 
@@ -792,7 +794,7 @@ class MatrixGraphic:
 
         center = z + self.matrix.L / 2.0
         axes.annotate(self.matrix.label, xy=(center, 0.0),
-                      xytext=(center, halfHeight * 1.35),
+                      xytext=(center, halfHeight * 1.4),
                       fontsize=8, xycoords='data', ha='center',
                       va='bottom', clip_box=axes.bbox, clip_on=True)
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -64,7 +64,7 @@ class Figure:
 
         if self.designParams['onlyPrincipalAndAxialRays']:
             (stopPosition, stopDiameter) = self.path.apertureStop()
-            if stopPosition is None:
+            if stopPosition is None or self.path.principalRay() is None:
                 warnings.warn("No aperture stop in system: cannot use onlyPrincipalAndAxialRays=True since they are "
                               "not defined.")
                 self.designParams['onlyPrincipalAndAxialRays'] = False

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -145,7 +145,7 @@ class Figure:
         else:
             self._showPlot()
 
-    def displayGaussianBeam(self, inputBeams=None, filepath=None):
+    def displayGaussianBeam(self, beams=None, filepath=None):
         """ Display the optical system and trace the laser beam.
         If comments are included they will be displayed on a
         graph in the bottom half of the plot.
@@ -156,7 +156,9 @@ class Figure:
             A list of Gaussian beams
         """
 
-        self.drawBeamTraces(beams=inputBeams)
+        if len(beams) != 0:
+            self.drawBeamTraces(beams=beams)
+
         self.drawDisplayObjects()
 
         self.axes.callbacks.connect('ylim_changed', self.onZoomCallback)
@@ -301,7 +303,10 @@ class Figure:
                 displayRange = graphic.halfHeight * 2
 
         if displayRange == float('+Inf') or displayRange == 0:
-            displayRange = self.path.inputBeam.w * 3
+            if self.path.inputBeam is not None:
+                displayRange = self.path.inputBeam.w * 3
+            else:
+                displayRange = 100
 
         return displayRange
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -274,8 +274,8 @@ class Figure:
     def imagingDisplayRange(self):
         displayRange = self.path.largestDiameter
 
-        if displayRange == float('+Inf') or displayRange <= 2 * self.path._objectHeight:
-            displayRange = 2 * self.path._objectHeight
+        if displayRange == float('+Inf') or displayRange <= self.path._objectHeight:
+            displayRange = self.path._objectHeight
 
         conjugates = self.path.intermediateConjugates()
         if len(conjugates) != 0:

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -775,7 +775,7 @@ class MatrixGraphic:
 
         center = z + self.matrix.L / 2.0
         axes.annotate(self.matrix.label, xy=(center, 0.0),
-                      xytext=(center, halfHeight * 1.4),
+                      xytext=(center, halfHeight * 1.35),
                       fontsize=8, xycoords='data', ha='center',
                       va='bottom', clip_box=axes.bbox, clip_on=True)
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -1007,6 +1007,10 @@ class LensGraphic(MatrixGraphic):
 
 
 class SpaceGraphic(MatrixGraphic):
+    def __init__(self, matrix):
+        super(SpaceGraphic, self).__init__(matrix)
+        self._halfHeight = 0
+
     def drawAt(self, z, axes, showLabels=False):
         """This function draws nothing because free space is not visible. """
         return

--- a/raytracing/gaussianbeam.py
+++ b/raytracing/gaussianbeam.py
@@ -144,10 +144,10 @@ class GaussianBeam(object):
             description += "w(z): {0:.3f}, ".format(self.w)
             description += "R(z): {0:.3f}, ".format(self.R)
             description += "z: {0:.3f}, ".format(self.z)
-            description += "λ: {0:.1f} nm\n".format(self.wavelength * 1e6)
+            description += "λ: {0:.1f} nm\n".format(self.wavelength)
             description += "zo: {0:.3f}, ".format(self.zo)
             description += "wo: {0:.3f}, ".format(self.wo)
             description += "wo position: {0:.3f} ".format(self.waistPosition)
             return description
         else:
-            return "Not valid complex radius of curvature"
+            return "Beam is not finite: q={0}".format(self.q)

--- a/raytracing/lasercavity.py
+++ b/raytracing/lasercavity.py
@@ -48,19 +48,23 @@ class LaserCavity(LaserPath):
         round trip: you will need to duplicate elements in reverse
         and append them manually.
 
+        Knowing that q = (Aq + B)/(Cq + d), we get
+        Cq^2 + Dq = Aq + B, therefore:
+        Cq^2 + (D-A)q - B = 0
+
+        and q = - ((D-A) +- sqrt( (D-A)^2 - 4 C (-B)))/(2C)
+
         You will typically obtain two values, where only one is physical.
         There could be two modes in a laser with complex matrices (i.e.
         with gain), but this is not considered here.  See "Lasers" by Siegman.
         """
         if not self.hasPower:
             return None, None
-
         b = self.D - self.A
-        sqrtDelta = cmath.sqrt(b * b + 4.0 * self.B * self.C)
+        sqrtDelta = cmath.sqrt(b * b - 4.0 * self.C * (-self.B))
 
         q1 = (- b + sqrtDelta) / (2.0 * self.C)
         q2 = (- b - sqrtDelta) / (2.0 * self.C)
-
         return (GaussianBeam(q=q1), GaussianBeam(q=q2))
 
     def laserModes(self):
@@ -91,5 +95,8 @@ class LaserCavity(LaserPath):
             graph in the bottom half of the plot. (default=None)
 
         """
+        beams = self.laserModes()
+        if len(beams) == 0:
+            print("Cavity is not stable")
 
-        super(LaserCavity, self).display(inputBeams=self.laserModes())
+        super(LaserCavity, self).display(beams=beams)

--- a/raytracing/laserpath.py
+++ b/raytracing/laserpath.py
@@ -53,7 +53,7 @@ class LaserPath(MatrixGroup):
         self.showPlanesAcrossPointsOfInterest = True
         super(LaserPath, self).__init__(elements=elements, label=label)
 
-    def display(self, inputBeam=None, inputBeams=None, comments=None):  # pragma: no cover
+    def display(self, beams=None, comments=None):  # pragma: no cover
         """ Display the optical system and trace the laser beam. 
         If comments are included they will be displayed on a
         graph in the bottom half of the plot.
@@ -67,16 +67,11 @@ class LaserPath(MatrixGroup):
             If comments are included they will be displayed on a graph in the bottom half of the plot. (default=None)
 
         """
-        if inputBeam is not None:
-            inputBeams = [inputBeam]
-            self.inputBeam = inputBeam
-        elif inputBeams is not None:
-            self.inputBeam = inputBeams[0]
-        else:
-            inputBeams = [self.inputBeam]
+        if beams is None :
+            beams = [self.inputBeam]
 
         figure = Figure(opticalPath=self)
 
         figure.createFigure(title=self.label, comments=comments)
 
-        figure.displayGaussianBeam(inputBeams=inputBeams)
+        figure.displayGaussianBeam(beams=beams)

--- a/raytracing/laserpath.py
+++ b/raytracing/laserpath.py
@@ -53,20 +53,26 @@ class LaserPath(MatrixGroup):
         self.showPlanesAcrossPointsOfInterest = True
         super(LaserPath, self).__init__(elements=elements, label=label)
 
-    def display(self, inputBeams=None, comments=None):  # pragma: no cover
+    def display(self, inputBeam=None, inputBeams=None, comments=None):  # pragma: no cover
         """ Display the optical system and trace the laser beam. 
         If comments are included they will be displayed on a
         graph in the bottom half of the plot.
 
         Parameters
         ----------
+        inputBeam : object of GaussianBeam class
         inputBeams : list of object of GaussianBeam class
             A list of Gaussian beams
         comments : string
             If comments are included they will be displayed on a graph in the bottom half of the plot. (default=None)
 
         """
-        if inputBeams is None:
+        if inputBeam is not None:
+            inputBeams = [inputBeam]
+            self.inputBeam = inputBeam
+        elif inputBeams is not None:
+            self.inputBeam = inputBeams[0]
+        else:
             inputBeams = [self.inputBeam]
 
         figure = Figure(opticalPath=self)

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1365,7 +1365,8 @@ class Matrix(object):
         return halfHeight
 
     def display(self):
-        MatrixGraphic(self).display()
+        from .figure import Graphic
+        return Graphic(self).display()
 
     def __str__(self):
         """ String description that allows the use of print(Matrix())

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1364,6 +1364,9 @@ class Matrix(object):
             halfHeight = self.apertureDiameter / 2.0  # real half height
         return halfHeight
 
+    def display(self):
+        MatrixGraphic(self).display()
+
     def __str__(self):
         """ String description that allows the use of print(Matrix())
 

--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -137,6 +137,10 @@ class AchromatDoubletLens(MatrixGroup):
         (f1, f2) = self.focusPositions(z)
         return [{'z': f1, 'label': '$F_f$'}, {'z': f2, 'label': '$F_b$'}]
 
+    def display(self):
+        from .figure import AchromatDoubletLensGraphic
+        return AchromatDoubletLensGraphic(self).display()
+
 
 class SingletLens(MatrixGroup):
     """

--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -137,11 +137,6 @@ class AchromatDoubletLens(MatrixGroup):
         (f1, f2) = self.focusPositions(z)
         return [{'z': f1, 'label': '$F_f$'}, {'z': f2, 'label': '$F_b$'}]
 
-    def display(self):
-        from .figure import AchromatDoubletLensGraphic
-        return AchromatDoubletLensGraphic(self).display()
-
-
 class SingletLens(MatrixGroup):
     """
     General singlet lens with an effective focal length of f, back focal

--- a/raytracing/tests/testsFigure.py
+++ b/raytracing/tests/testsFigure.py
@@ -19,7 +19,7 @@ class TestFigure(unittest.TestCase):
         path.append(Space(2))
         path.append(CurvedMirror(-5, 10))
 
-        self.assertAlmostEqual(path.figure.displayRange(), 20)
+        self.assertAlmostEqual(path.figure.displayRange(), 10)
 
         path.objectHeight = 1
         self.assertEqual(path.figure.displayRange(), 10)
@@ -27,7 +27,7 @@ class TestFigure(unittest.TestCase):
     def testDisplayRangeWithEmptyPath(self):
         path = ImagingPath()
 
-        largestDiameter = path.objectHeight * 2
+        largestDiameter = path.objectHeight
 
         self.assertEqual(path.figure.displayRange(), largestDiameter)
 

--- a/raytracing/tests/testsFigure.py
+++ b/raytracing/tests/testsFigure.py
@@ -5,23 +5,28 @@ from raytracing import *
 
 
 class TestFigure(unittest.TestCase):
-    def testDisplayRangeWithFiniteLens(self):
+    @patch('raytracing.Figure._showPlot')
+    def testDisplayRangeWithFiniteLens(self, mock):
         path = ImagingPath()  # default objectHeight is 10
         path.append(Space(d=10))
         path.append(Lens(f=5, diameter=20))
+        path.display()
 
         largestDiameter = 20
 
         self.assertEqual(path.figure.displayRange(), largestDiameter)
 
-    def testDisplayRangeImageOutOfView(self):
+    @patch('raytracing.Figure._showPlot')
+    def testDisplayRangeImageOutOfView(self, mock):
         path = ImagingPath()
         path.append(Space(2))
         path.append(CurvedMirror(-5, 10))
+        path.display()
 
         self.assertAlmostEqual(path.figure.displayRange(), 10)
 
         path.objectHeight = 1
+        path.display()
         self.assertEqual(path.figure.displayRange(), 10)
 
     def testDisplayRangeWithEmptyPath(self):
@@ -70,19 +75,8 @@ class TestFigureAxesToDataScale(unittest.TestCase):
 
         xScaling, yScaling = figure.axesToDataScale()
 
-        self.assertEqual(xScaling, 1)
-        self.assertEqual(yScaling, 1)
-
-    def testWithForcedScale(self):
-        figure = Figure(ImagingPath())
-        figure.createFigure()
-        figure.axes.set_xlim(-10, 10)
-        figure.axes.set_ylim(-5, 5)
-
-        xScaling, yScaling = figure.axesToDataScale()
-
-        self.assertEqual(xScaling, 20)
-        self.assertEqual(yScaling, 10)
+        self.assertEqual(xScaling, 0)
+        self.assertEqual(yScaling, 10 * 1.6)
 
     @unittest.skipIf(sys.platform == 'darwin',"FIXME: We hacked plt.show() on darwin to recover Ctrl-C")
     @patch('matplotlib.pyplot.show')
@@ -96,7 +90,7 @@ class TestFigureAxesToDataScale(unittest.TestCase):
 
         (xScaling, yScaling) = path.figure.axesToDataScale()
 
-        self.assertEqual(yScaling, path.figure.displayRange() * 1.5)
+        self.assertEqual(yScaling, path.figure.displayRange() * 1.6)
         self.assertEqual(xScaling, 20 * 1.1)
 
 

--- a/raytracing/tests/testsGaussian.py
+++ b/raytracing/tests/testsGaussian.py
@@ -114,7 +114,8 @@ class TestBeam(envtest.RaytracingTestCase):
 
     def testStrInvalidRadiusOfCurvature(self):
         beam = GaussianBeam(w=inf, R=1)
-        self.assertEqual(str(beam), "Not valid complex radius of curvature")
+        self.assertFalse(beam.isFinite)
+        self.assertEqual(str(beam), "Beam is not finite: q=(1+0j)")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fix #279

- Block the use of 'onlyPrincipalAndAxialRays' if ImagingPath.principalRay() is None
- Fixed ThickLens graphic
- Fixed many displayRange and plt scaling issues

#### update
- Fixed graphic for subclasses of specialty lenses
- Added display method in Matrix() which calls Graphic(self) to display any Matrix or MatrixGroup subclasses correctly. 