### PR TITLE
Name conflict between save (MatrixGroup elements) and save (ImagingPath's figure) is no more

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -7,7 +7,7 @@ path.append(Space(d=10))
 path.append(Lens(f=5))
 path.append(Space(d=10))
 path.display()
-# path.save('Figure1.png')
+# path.saveFigure('Figure1.png')
 
 path = ImagingPath()
 path.label = "Object at 4f, image at 4f/3"
@@ -15,7 +15,7 @@ path.append(Space(d=20))
 path.append(Lens(f=5))
 path.append(Space(d=10))
 path.display()
-# path.save('Figure2.png')
+# path.saveFigure('Figure2.png')
 
 path = ImagingPath()
 path.label = "Object at 4f, virtual image at"
@@ -23,7 +23,7 @@ path.append(Space(d=2.5))
 path.append(Lens(f=5))
 path.append(Space(d=10))
 path.display()
-# path.save('Figure2.png')
+# path.saveFigure('Figure2.png')
 
 path = ImagingPath()
 path.label = "4f system"
@@ -33,7 +33,7 @@ path.append(Space(d=10))
 path.append(Lens(f=5))
 path.append(Space(d=5))
 path.display()
-# path.save('Figure3.png')
+# path.saveFigure('Figure3.png')
 
 path = ImagingPath()
 path.fanAngle = 0.1

--- a/examples/illuminator.py
+++ b/examples/illuminator.py
@@ -19,4 +19,4 @@ path.showLabels=True
 print(path.fieldStop())
 print(path.fieldOfView())
 path.display(onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
-path.save("Illumination.png",onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
+path.saveFigure("Illumination.png", onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)

--- a/examples/invariant.py
+++ b/examples/invariant.py
@@ -9,7 +9,7 @@ path.append(Space(d=15))
 path.append(Lens(f=10,diameter=2.5))
 path.append(Space(d=10))
 path.display()
-#path.save('object-smallLenses.png')
+#path.saveFigure('object-smallLenses.png')
 
 path = ImagingPath()
 path.name = "4f system, 1 cm object, small and large lenses"
@@ -19,7 +19,7 @@ path.append(Space(d=15))
 path.append(Lens(f=10,diameter=5))
 path.append(Space(d=10))
 path.display()
-#path.save('object-smallLargeLenses.png')
+#path.saveFigure('object-smallLargeLenses.png')
 
 path = ImagingPath()
 path.name = "4f system, calculated field of view, small lenses"
@@ -29,7 +29,7 @@ path.append(Space(d=15))
 path.append(Lens(f=10,diameter=2.5))
 path.append(Space(d=10))
 path.display(onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
-#path.save('fov-smallLenses.png', onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
+#path.saveFigure('fov-smallLenses.png', onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
 
 path = ImagingPath()
 path.name = "4f system, improved field of view, small and large lenses"
@@ -39,7 +39,7 @@ path.append(Space(d=15))
 path.append(Lens(f=10,diameter=5.0))
 path.append(Space(d=10))
 path.display(onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
-#path.save('fov-smallLargeLenses.png', onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
+#path.saveFigure('fov-smallLargeLenses.png', onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
 
 path = ImagingPath()
 path.name = "4f systeme, no change in field of view with large first lens"
@@ -49,4 +49,4 @@ path.append(Space(d=15))
 path.append(Lens(f=10,diameter=5.0))
 path.append(Space(d=10))
 path.display(onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
-#path.save('fov-largeLenses.png', onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)
+#path.saveFigure('fov-largeLenses.png', onlyChiefAndMarginalRays=True, limitObjectToFieldOfView=True)

--- a/raytracing/__main__.py
+++ b/raytracing/__main__.py
@@ -67,7 +67,7 @@ if 2 in examples:
     path.display()
     """)
     # or
-    # path.save("Figure 2.pdf")
+    # path.saveFigure("Figure 2.pdf")
 
 if 3 in examples:
     path = ImagingPath()

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -716,10 +716,10 @@ class ImagingPath(MatrixGroup):
         self.figure.display(onlyPrincipalAndAxialRays=onlyPrincipalAndAxialRays,
                             removeBlockedRaysCompletely=removeBlockedRaysCompletely)
 
-    def save(self, filepath,
-             onlyPrincipalAndAxialRays=True,
-             removeBlockedRaysCompletely=False, comments=None,
-             limitObjectToFieldOfView=None, onlyChiefAndMarginalRays=None):
+    def saveFigure(self, filepath,
+                   onlyPrincipalAndAxialRays=True,
+                   removeBlockedRaysCompletely=False, comments=None,
+                   limitObjectToFieldOfView=None, onlyChiefAndMarginalRays=None):
         """
         The figure of the imaging path can be saved using this function.
 

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -161,7 +161,7 @@ class TestImagingPath(envtest.RaytracingTestCase):
         filename = self.tempFilePath("test.png")
         comments = "This is a test"
         path = ImagingPath(System4f(10, 10, 10, 10))
-        path.save(filename, comments=comments)
+        path.saveFigure(filename, comments=comments)
         if not os.path.exists(filename):
             self.fail("No file saved (with comments)")
         os.remove(filename)
@@ -169,7 +169,7 @@ class TestImagingPath(envtest.RaytracingTestCase):
     def testSaveWithoutComments(self):
         filename = self.tempFilePath("test.png")
         path = ImagingPath(System4f(10, 10, 10, 10))
-        path.save(filename)
+        path.saveFigure(filename)
         if not os.path.exists(filename):
             self.fail("No file saved (without comments)")
         os.remove(filename)


### PR DESCRIPTION
There was a name conflict between `save`, the method in `MatrixGroup` that is used to save the elements of the group, and `save`, the method in `ImagingPath` that is used to save a figure of the current path. Now, the latter is `saveFigure` so the former is not overriden.

Fixes #284 