### PR TITLE
Ray: fanGroup and fan are deprecated.

### DIFF
--- a/raytracing/ray.py
+++ b/raytracing/ray.py
@@ -1,3 +1,6 @@
+import warnings
+
+
 class Ray:
     """A vector and a light ray as transformed by ABCD matrices.
 
@@ -32,7 +35,7 @@ class Ray:
 
     """
 
-    def __init__(self, y: float = 0, theta: float = 0, z: float = 0, isBlocked:bool = False):
+    def __init__(self, y: float = 0, theta: float = 0, z: float = 0, isBlocked: bool = False):
         self.y = y
         self.theta = theta
 
@@ -81,12 +84,18 @@ class Ray:
         rays : list of ray
             The created list of rays that define this fan.
 
+        Notes
+        -----
+        This method is deprecated. The class Rays and its subclasses should be used to generate multiple Ray objects.
+
         See Also
         --------
         raytracing.Matrix.trace()
         raytracing.Matrix.traceMany().
 
         """
+        warnings.warn("The creation of a group of rays with this method is deprecated. Usage of the class Rays and its"
+                      "subclasses is recommended.", DeprecationWarning)
 
         if N >= 2:
             deltaRadian = float(radianMax - radianMin) / (N - 1)
@@ -129,13 +138,19 @@ class Ray:
         rays : list of ray
             The created list of rays that define these fan groups.
 
+        Notes
+        -----
+        This method is deprecated. The class Rays and its subclasses should be used to generate multiple Ray objects.
+
         See Also
         --------
         raytracing.Matrix.trace()
         raytracing.Matrix.traceMany().
 
         """
-        
+        warnings.warn("The creation of a group of rays with this method is deprecated. Usage of the class Rays and its"
+                      "subclasses is recommended.", DeprecationWarning)
+
         if N >= 2:
             deltaRadian = float(radianMax - radianMin) / (N - 1)
         elif N == 1:


### PR DESCRIPTION
A warning message is printed, recommending the use of `Rays` and its subclasses to generate rays. It is important to notify current users that those methods should not be used, because better alternatives exist. Maybe we should add that they will be deleted in the future.