### PR TITLE
Fix traceManyThroughInParallel progress display

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -829,10 +829,10 @@ class Matrix(object):
             processes = multiprocessing.cpu_count()
 
         theExplicitList = list(inputRays)
-        manyInputRays = [theExplicitList[i::processes] for i in range(processes)]
+        manyInputRays = [(theExplicitList[i::processes], progress) for i in range(processes)]
 
         with multiprocessing.Pool(processes=processes) as pool:
-            outputRays = pool.map(self.traceManyThrough, manyInputRays)
+            outputRays = pool.starmap(self.traceManyThrough, manyInputRays)
 
         outputRaysList = []
         for rays in outputRays:

--- a/raytracing/tests/testCallOtherScript.py
+++ b/raytracing/tests/testCallOtherScript.py
@@ -44,3 +44,7 @@ if __name__ == "__main__":
             f.write(code)
         printed = subprocess.check_output(self.exec + " " + self.printHelloWorld, universal_newlines=True)
         self.assertEqual(printed.strip(), "Hello Toto\nHello Toto Jr.")
+
+
+if __name__ == '__main__':
+    envtest.main()

--- a/raytracing/tests/testCallOtherScript.py
+++ b/raytracing/tests/testCallOtherScript.py
@@ -1,0 +1,46 @@
+import envtest
+import sys
+import subprocess
+
+
+class TestCallScript(envtest.RaytracingTestCase):
+    def setUp(self):
+        self.exec = sys.executable
+        self.encoding = sys.stdout.encoding
+        self.emptyFile = self.tempFilePath('script.py')
+        open(self.emptyFile, "w").close()
+        self.printHelloWorld = self.tempFilePath('helloWorld.py')
+        with open(self.printHelloWorld, "w") as helloWorld:
+            helloWorld.write('''print("hello world")''')
+
+    def testCallFileNotFound(self):
+        file = " fileDoesNotExist.py"  # Leading space important
+        sts = subprocess.call(self.exec + file)
+        self.assertEqual(sts, 2)
+
+    def testCallScript(self):
+        sts = subprocess.call(self.exec + " " + self.emptyFile)
+        self.assertEqual(sts, 0)
+
+    def testGetWhatIsPrinted(self):
+        printed = subprocess.check_output(self.exec + " " + self.printHelloWorld)
+        printed = printed.decode(self.encoding)
+        self.assertEqual(printed.strip(), "hello world")
+
+    def testGetWhatIsPrintedWithChildProcesses(self):
+        code = """
+import multiprocessing
+
+def printHelloName(name):
+    print(f"Hello {name}")
+
+if __name__ == "__main__":
+    inputNames = ["Toto", "Toto Jr."]
+    processes = 4
+    with multiprocessing.Pool(processes=processes) as pool:
+        outputValues = pool.map(printHelloName, inputNames)
+""".strip()
+        with open(self.printHelloWorld, "w") as f:
+            f.write(code)
+        printed = subprocess.check_output(self.exec + " " + self.printHelloWorld, universal_newlines=True)
+        self.assertEqual(printed.strip(), "Hello Toto\nHello Toto Jr.")

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -1,6 +1,5 @@
 import envtest  # modifies path
-import platform
-import sys
+from subprocess import check_output
 
 from raytracing import *
 
@@ -398,6 +397,20 @@ class TestMatrix(envtest.RaytracingTestCase):
                 self.assertIn(traceWithNumberProcesses[i], rays)
         except Exception as exception:
             self.fail(f"Exception raised:\n{exception}")
+
+    @envtest.skipIf(sys.platform == 'darwin' and sys.version_info.major == 3 and sys.version_info.minor <= 7,
+                    "Endless loop on macOS")
+    # Some information here: https://github.com/gammapy/gammapy/issues/2453
+    def testTraceManyThroughInParallelNoOutput(self):
+        output = check_output(sys.executable + " traceManyThroughInParallelNoOutput.py", universal_newlines=True)
+        self.assertEqual(output, "")
+
+    @envtest.skipIf(sys.platform == 'darwin' and sys.version_info.major == 3 and sys.version_info.minor <= 7,
+                    "Endless loop on macOS")
+    # Some information here: https://github.com/gammapy/gammapy/issues/2453
+    def testTraceManyThroughInParallelWithOutput(self):
+        output = check_output(sys.executable + " traceManyThroughInParallelWithOutput.py", universal_newlines=True)
+        self.assertEqual(output.strip(), "Progress 10000/10000 (100%) \nProgress 10000/10000 (100%)")
 
     def testPointsOfInterest(self):
         m = Matrix()

--- a/raytracing/tests/testsMultiprocessor.py
+++ b/raytracing/tests/testsMultiprocessor.py
@@ -1,11 +1,16 @@
 import envtest  # modifies path
 from raytracing import *
+import itertools
 
 inf = float("+inf")
 
 
 def multiplyBy2(value) -> float:
     return 2 * value
+
+
+def mul(value1, value2) -> float:
+    return value1 * value2
 
 
 class TestMultiProcessorSupport(envtest.RaytracingTestCase):
@@ -18,6 +23,17 @@ class TestMultiProcessorSupport(envtest.RaytracingTestCase):
         with multiprocessing.Pool(processes=processes) as pool:
             outputValues = pool.map(multiplyBy2, inputValues)
         self.assertEqual(outputValues, list(map(multiplyBy2, inputValues)))
+
+    @envtest.skipIf(sys.platform == 'darwin' and sys.version_info.major == 3 and sys.version_info.minor <= 7,
+                    "Endless loop on macOS")
+    # Some information here: https://github.com/gammapy/gammapy/issues/2453
+    def testMultiPoolWith2Args(self):
+        processes = 4
+        inputValues = [1, 2, 3, 4]
+        with multiprocessing.Pool(processes=processes) as pool:
+            outputValues = pool.starmap(mul, itertools.product(inputValues, [2]))
+        func = lambda val1: mul(val1, 2)
+        self.assertEqual(outputValues, list(map(func, inputValues)))
 
 
 if __name__ == '__main__':

--- a/raytracing/tests/traceManyThroughInParallelNoOutput.py
+++ b/raytracing/tests/traceManyThroughInParallelNoOutput.py
@@ -1,0 +1,8 @@
+import envtest
+
+from raytracing import *
+
+if __name__ == '__main__':
+    rays = [Ray(y, y) for y in range(20_000)]
+    m = Matrix(physicalLength=1)
+    m.traceManyThroughInParallel(rays, processes=2, progress=False)

--- a/raytracing/tests/traceManyThroughInParallelWithOutput.py
+++ b/raytracing/tests/traceManyThroughInParallelWithOutput.py
@@ -1,0 +1,8 @@
+import envtest
+
+from raytracing import *
+
+if __name__ == '__main__':
+    rays = [Ray(y, y) for y in range(20_000)]
+    m = Matrix(physicalLength=1)
+    m.traceManyThroughInParallel(rays, processes=2, progress=True)


### PR DESCRIPTION
There was an argument in `traceManyThroughInParallel` that was not used and that should indicate if we want to display the tracing progress. Instead of using `Pool.map`, I used `Pool.starmap` which allows more than one argument to be transfered to the method we want to map. For example:
````python
...
with multiprocessing.Pool(processes=processes) as pool:
    outputRays = pool.starmap(self.traceManyThrough, [([<bunch of rays>], True), [(<bunch of rays>], True), ...])
...
````
will give to `traceManyThrough` `([<bunch of rays>], True)`, so it will trace `[<bunch of rays>]` and display its progress because we set the progress as `True` (setting it at `False` would not display anything).

I tested it. For `traceManyThrough`, since it doesn't involve any child process, checking if the progress is indeed printed is quite easy: we simply have to redirect the standard output to some IO object and then check the content of said IO object. But when it involves child processes, we cannot use `contextlib` and its `redirect_stdout` context manager (see the last paragraph of the `redirect_stdout` section https://docs.python.org/3/library/contextlib.html#contextlib.redirect_stdout). In order to test it, I had to use my imagination. After searching the internet (mainly stack overflow), I discovered some messy and quite not intuitive ways to access the standard output of children. I also discovered that we can access the output of a script that we run through *externally*: it is `check_output` from the `subprocess` module. How it works? It runs an excutable and returns what is printed (through standard output I guess). Why is it relevant? Because we can simply run a script that prints things with child processes and access the script's output. For example:
````python
# This is helloworld.py
print("hello world")
````
````python
# This is runHelloworld.py (in same dir as helloworld.py)
from subprocess import check_output

output = check_output(f"python helloworld.py", universal_newlines=True) # Kind of same thing as opening cmd and writing python <script name>.py
````
The variable `output` contains `"hello world"`. If we use different sub processes, it works like a charm (except for Windows end of line `\r\n`, but thankfully the keyword `universal_newlines` exists!).

I experimented with `call` and `check_ouput` in a new test file to better understand how it works and what we can do with it. With this workarround, we can test if the parallel version of `traceManyThrough` displays the progress. To fully test is, I however needed to create to new files, one that trace rays without showing progress and another one that displays progress.

Fixes #294 