### PR TITLE
Creation of `utils.py` for recovering performance

### DIFF
--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -49,12 +49,6 @@ digraph G {
 
 import math
 
-""" Two constants: deg and rad to quickly convert to degrees
-or radians with angle*degPerRad or angle*radPerDeg """
-
-degPerRad = 180.0/math.pi
-radPerDeg = math.pi/180.0
-
 """ We import almost everything by default, in the general namespace because it is simpler for everyone """
 
 """ General matrices and groups for tracing rays and gaussian beams"""
@@ -81,7 +75,6 @@ from .axicon import *
 from . import thorlabs
 from . import eo
 from . import olympus
-
 
 """ Synonym of Matrix: Element 
 

--- a/raytracing/gaussianbeam.py
+++ b/raytracing/gaussianbeam.py
@@ -45,7 +45,7 @@ class GaussianBeam(object):
             raise ValueError("Please specify 'q' or 'w'.")
 
         if q is not None and w is not None:
-            if areNotEqualRelative(self.q, q, relTol):
+            if areRelativelyNotEqual(self.q, q, relTol):
                 msg = f"Mismatch between the given q '{q}' and the computed q '{self.q}' ({relTol * 100}% tolerance)."
                 raise ValueError(msg)
 

--- a/raytracing/gaussianbeam.py
+++ b/raytracing/gaussianbeam.py
@@ -1,6 +1,6 @@
 import math
 import cmath
-
+from .utils import *
 
 class GaussianBeam(object):
     """A gaussian laser beam using the ABCD formalism for propagation of complex radius of curvature q.
@@ -44,7 +44,7 @@ class GaussianBeam(object):
             raise ValueError("Please specify 'q' or 'w'.")
 
         if q is not None and w is not None:
-            if not cmath.isclose(a=self.q, b=q, rel_tol=relTol):
+            if areNotEqual(self.q.real, q.real) or areNotEqual(self.q.imag, q.imag):
                 msg = f"Mismatch between the given q '{q}' and the computed q '{self.q}' ({relTol * 100}% tolerance)."
                 raise ValueError(msg)
 

--- a/raytracing/gaussianbeam.py
+++ b/raytracing/gaussianbeam.py
@@ -2,6 +2,7 @@ import math
 import cmath
 from .utils import *
 
+
 class GaussianBeam(object):
     """A gaussian laser beam using the ABCD formalism for propagation of complex radius of curvature q.
 
@@ -44,7 +45,7 @@ class GaussianBeam(object):
             raise ValueError("Please specify 'q' or 'w'.")
 
         if q is not None and w is not None:
-            if areNotEqual(self.q.real, q.real) or areNotEqual(self.q.imag, q.imag):
+            if areNotEqualRelative(self.q, q, relTol):
                 msg = f"Mismatch between the given q '{q}' and the computed q '{self.q}' ({relTol * 100}% tolerance)."
                 raise ValueError(msg)
 
@@ -80,7 +81,7 @@ class GaussianBeam(object):
         """
         if self.q == 0:
             return False
-            
+
         return (-1 / self.q).imag > 0
 
     @property

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -137,8 +137,10 @@ class Matrix(object):
         self.label = label
         self.isFlipped = False
         super(Matrix, self).__init__()
-        if not isclose(self.determinant, self.frontIndex / self.backIndex, atol=self.__epsilon__):
-            raise ValueError("The matrix has inconsistent values")
+
+        if areNotEqual(self.determinant, frontIndex / backIndex, self.__epsilon__):
+            raise ValueError("The matrix has inconsistent values: \
+                determinant is incorrect considering front and back indices.")
 
     @property
     def isIdentity(self):

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -869,7 +869,7 @@ class Matrix(object):
         And as usual, C = -1/f (always).
         """
 
-        return abs(self.B) < Matrix.__epsilon__
+        return isAlmostZero(self.B, self.__epsilon__)
 
     @property
     def hasPower(self):
@@ -889,7 +889,7 @@ class Matrix(object):
         >>> print('hasPower:' , M2.hasPower)
         hasPower: False
         """
-        return abs(self.C) > Matrix.__epsilon__
+        return isNotZero(self.C, self.__epsilon__)
 
     def pointsOfInterest(self, z):
         """ Any points of interest for this matrix (focal points,

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -138,7 +138,7 @@ class Matrix(object):
         self.isFlipped = False
         super(Matrix, self).__init__()
 
-        if areNotEqual(self.determinant, frontIndex / backIndex, self.__epsilon__):
+        if areAbsolutelyNotEqual(self.determinant, frontIndex / backIndex, self.__epsilon__):
             raise ValueError("The matrix has inconsistent values: \
                 determinant is incorrect considering front and back indices.")
 

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -402,7 +402,7 @@ class MatrixGroup(Matrix):
                 planePosition = transferMatrix.L + distance
                 if planePosition != 0 and conjugate is not None:
                     magnification = conjugate.A
-                    if any([isclose(pos, planePosition) and isclose(mag, magnification) for pos, mag in planes]):
+                    if any([areAlmostEqual(pos, planePosition) and areAlmostEqual(mag, magnification) for pos, mag in planes]):
                         continue
                     else:
                         planes.append([planePosition, magnification])

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -402,7 +402,7 @@ class MatrixGroup(Matrix):
                 planePosition = transferMatrix.L + distance
                 if planePosition != 0 and conjugate is not None:
                     magnification = conjugate.A
-                    if any([areAlmostEqual(pos, planePosition) and areAlmostEqual(mag, magnification) for pos, mag in planes]):
+                    if any([areAbsolutelyAlmostEqual(pos, planePosition) and areAbsolutelyAlmostEqual(mag, magnification) for pos, mag in planes]):
                         continue
                     else:
                         planes.append([planePosition, magnification])

--- a/raytracing/ray.py
+++ b/raytracing/ray.py
@@ -94,7 +94,7 @@ class Ray:
         raytracing.Matrix.traceMany().
 
         """
-        warnings.warn("The creation of a group of rays with this method is deprecated. Usage of the class Rays and its"
+        warnings.warn("The creation of a group of rays with this method is deprecated. Usage of the class Rays and its "
                       "subclasses is recommended.", DeprecationWarning)
 
         if N >= 2:

--- a/raytracing/tests/testsGaussian.py
+++ b/raytracing/tests/testsGaussian.py
@@ -117,6 +117,12 @@ class TestBeam(envtest.RaytracingTestCase):
         self.assertFalse(beam.isFinite)
         self.assertEqual(str(beam), "Beam is not finite: q=(1+0j)")
 
+    def testPerformance(self):
+        path = LaserPath()
+        path.append(Space(100))
+        beamIn = GaussianBeam(w=0.01, R=1, n=1.5, wavelength=0.400e-3)
 
+        path.trace(beamIn)
+        
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -1,0 +1,20 @@
+import math
+
+""" Two constants: deg and rad to quickly convert to degrees
+or radians with angle*degPerRad or angle*radPerDeg """
+
+degPerRad = 180.0/math.pi
+radPerDeg = math.pi/180.0
+
+def isAlmostZero(value, epsilon=1e-3):
+    return abs(value) < epsilon
+
+def isNotZero(value, epsilon=1e-3):
+    return abs(value) > epsilon
+
+def areAlmostEqual(left, right, epsilon=1e-3):
+    return abs(left-right) < epsilon
+
+def areNotEqual(left, right, epsilon=1e-3):
+    return abs(left-right) > epsilon
+

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -21,8 +21,8 @@ def areAlmostEqual(left, right, epsilon=1e-3):
 
 def areAlmostEqualRelative(left, right, epsilon=1e-3):
     absDiff = abs(left - right)
-    relTol1 = absDiff / left
-    relTol2 = absDiff / right
+    relTol1 = absDiff / abs(left)
+    relTol2 = absDiff / abs(right)
     return relTol1 < epsilon or relTol2 < epsilon
 
 

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -15,20 +15,20 @@ def isNotZero(value, epsilon=1e-3):
     return abs(value) > epsilon
 
 
-def areAlmostEqual(left, right, epsilon=1e-3):
+def areAbsolutelyAlmostEqual(left, right, epsilon=1e-3):
     return abs(left - right) < epsilon
 
 
-def areAlmostEqualRelative(left, right, epsilon=1e-3):
+def areRelativelyAlmostEqual(left, right, epsilon=1e-3):
     absDiff = abs(left - right)
     relTol1 = absDiff / abs(left)
     relTol2 = absDiff / abs(right)
     return relTol1 < epsilon or relTol2 < epsilon
 
 
-def areNotEqual(left, right, epsilon=1e-3):
+def areAbsolutelyNotEqual(left, right, epsilon=1e-3):
     return abs(left - right) > epsilon
 
 
-def areNotEqualRelative(left, right, epsilon=1e-3):
-    return not areAlmostEqualRelative(left, right, epsilon)
+def areRelativelyNotEqual(left, right, epsilon=1e-3):
+    return not areRelativelyAlmostEqual(left, right, epsilon)

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -3,18 +3,32 @@ import math
 """ Two constants: deg and rad to quickly convert to degrees
 or radians with angle*degPerRad or angle*radPerDeg """
 
-degPerRad = 180.0/math.pi
-radPerDeg = math.pi/180.0
+degPerRad = 180.0 / math.pi
+radPerDeg = math.pi / 180.0
+
 
 def isAlmostZero(value, epsilon=1e-3):
     return abs(value) < epsilon
 
+
 def isNotZero(value, epsilon=1e-3):
     return abs(value) > epsilon
 
+
 def areAlmostEqual(left, right, epsilon=1e-3):
-    return abs(left-right) < epsilon
+    return abs(left - right) < epsilon
+
+
+def areAlmostEqualRelative(left, right, epsilon=1e-3):
+    absDiff = abs(left - right)
+    relTol1 = absDiff / left
+    relTol2 = absDiff / right
+    return relTol1 < epsilon or relTol2 < epsilon
+
 
 def areNotEqual(left, right, epsilon=1e-3):
-    return abs(left-right) > epsilon
+    return abs(left - right) > epsilon
 
+
+def areNotEqualRelative(left, right, epsilon=1e-3):
+    return not areAlmostEqualRelative(left, right, epsilon)


### PR DESCRIPTION
The numpy function `isclose` is actualy surprinsingly slow.  I was able to create a smalleer function that is 10x faster.  Since we are using it in `Matrix.__init__`, it is critical to be fast and as it stood, it slowed down the plotting of LaserPath and others significantly.  I created 4 functions:
`isAlmostZero()`, `isAlmostOne()`, `areAlmostEqual()` and `areNotEqual()`

These functions are now in a new file called `utils.py`, with a few other functions.

I was not able to create a test to measure the performance before and after. However, I did use:
`python -m cProfile -s time -m raytracing -e 19 | more`

to show that `__init__` went from 2 seconds to 0.144 seconds:
```
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    1081    1.746    0.002    1.791    0.002 {method 'start_event_loop' of '_macosx.FigureCanvas' objects}
    1081    0.470    0.000    0.537    0.000 {method 'show' of '_macosx.FigureManager' objects}
    81434    0.137    0.000    0.311    0.000 matrix.py:199(mul_matrix)
    82253    0.121    0.000    0.144    0.000 matrix.py:102(__init__)
```