### PR TITLE
ImagingPath's ray fan variables should not be used. They are deprecated.

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -559,12 +559,12 @@ class Figure:
         else:
             halfAngle = self.path.fanAngle / 2.0
             halfHeight = self.path.objectHeight / 2.0
-            rayGroup = Ray.fanGroup(
+            rayGroup = UniformRays(
                 yMin=-halfHeight,
                 yMax=halfHeight,
                 M=self.path.rayNumber,
-                radianMin=-halfAngle,
-                radianMax=halfAngle,
+                thetaMin=-halfAngle,
+                thetaMax=halfAngle,
                 N=self.path.fanNumber)
             linewidth = 0.5
 

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -106,14 +106,14 @@ class ImagingPath(MatrixGroup):
 
     @property
     def fanAngle(self):
-        msg = "The usage of the 'fanAngle' property is deprecated and will be removed in a future version. "
+        msg = "The use of the 'fanAngle' property is deprecated and will be removed in a future version. "
         msg += "Please refer to updateRays to modify the generated rays."
         warnings.warn(msg, DeprecationWarning)
         return self._fanAngle
 
     @fanAngle.setter
     def fanAngle(self, fanAngle: float):
-        msg = "The usage of the 'fanAngle' property is deprecated and will be removed in a future version. "
+        msg = "The use of the 'fanAngle' property is deprecated and will be removed in a future version. "
         msg += "Please refer to updateRays to modify the generated rays."
         warnings.warn(msg, DeprecationWarning)
         self._fanAngle = fanAngle
@@ -121,14 +121,14 @@ class ImagingPath(MatrixGroup):
 
     @property
     def fanNumber(self):
-        msg = "The usage of the 'fanNumber' property is deprecated and will be removed in a future version. "
+        msg = "The use of the 'fanNumber' property is deprecated and will be removed in a future version. "
         msg += "Please refer to updateRays to modify the generated rays."
         warnings.warn(msg, DeprecationWarning)
         return self._fanNumber
 
     @fanNumber.setter
     def fanNumber(self, fanNumber: int):
-        msg = "The usage of the 'fanNumber' property is deprecated and will be removed in a future version. "
+        msg = "The use of the 'fanNumber' property is deprecated and will be removed in a future version. "
         msg += "Please refer to updateRays to modify the generated rays."
         warnings.warn(msg, DeprecationWarning)
         if fanNumber <= 0:
@@ -138,14 +138,14 @@ class ImagingPath(MatrixGroup):
 
     @property
     def rayNumber(self):
-        msg = "The usage of the 'rayNumber' property is deprecated and will be removed in a future version. "
+        msg = "The use of the 'rayNumber' property is deprecated and will be removed in a future version. "
         msg += "Please refer to updateRays to modify the generated rays."
         warnings.warn(msg, DeprecationWarning)
         return self._rayNumber
 
     @rayNumber.setter
     def rayNumber(self, numberOfRays: int):
-        msg = "The usage of the 'rayNumber' property is deprecated and will be removed in a future version. "
+        msg = "The use of the 'rayNumber' property is deprecated and will be removed in a future version. "
         msg += "Please refer to updateRays to modify the generated rays."
         warnings.warn(msg, DeprecationWarning)
         if numberOfRays <= 0:


### PR DESCRIPTION
**This is still a work on progress. I want to get your feedback on this before I dive too much in it**

Since we have classes such as `UniformRays`, `RandomRays`, etc, using `Ray` static methods `fan` and `fanGroup` is not really recommended anymore. Hence, we should not use multiple variables in `ImagingPath` (`fanAngle`, `fanNumber`, `rayNumber`).

I implemented properties getter / setter for those 3 attributes. With that, we don't change the API and it allows us to send warnings about the deprecation of them. It adds quite some code lines, but eventually in a future version we could simply remove the variables and remove said code lines. Current users are now warned that they should change their code because we will eventually remove `fanAngle`, `fanNumber`, `rayNumber`. I searched a bit on internet to know if there was a simpler way to add deprecation warnings to attributes, but I didn't find anything simpler.

I also created a new property, `rays`, which is a `UniforRays` instance. It is initialized in the constructor with default values and it can be updated with `updateRays` method. This method takes `yMax`, `yMin`, `thetaMax`, `thetaMin`, `M`, `N` to create new rays.

I did not test it before creating this <s>pull</s> review request. I also did not change anything related to demos that involves `fanAngle`, `fanNumber`, `rayNumber`. I want to know what you think before I modify too many lines.

Might fix #266