### PR TITLE
Syntax error : use of is instead of ==, fixed

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -112,8 +112,8 @@ class Figure:
                            'imageColor': imageColor, 'objectColor': objectColor}
         for key, value in newDesignParams.items():
             if value is not None:
-                if key is 'rayColors':
-                    assert len(value) is 3, \
+                if key == 'rayColors':
+                    assert len(value) == 3, \
                         "rayColors has to be a list with 3 elements."
                 self.designParams[key] = value
 


### PR DESCRIPTION
In `figure.py`, line 115 and 116 were written with "is", which is ok with 3.8 but not 3.6.  I think it is better to maintain 3.6 compatibility.
Incorrect justification: see below