### PR TITLE
Rays based display

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -631,8 +631,8 @@ class Figure:
         yScale : float
             The scale of y axes
         """
-        xScale = self.path.L * 1.1
-        yScale = self.displayRange() * 1.6
+
+        xScale, yScale = self.axes.viewLim.bounds[2:]
 
         return xScale, yScale
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -548,28 +548,10 @@ class Figure:
         2. the principal and axial rays.
         """
 
-        color = self.designParams['rayColors']
+        colors = self.designParams['rayColors']
 
-        # if self.designParams['onlyPrincipalAndAxialRays']:
-        #     halfHeight = self.path.objectHeight / 2.0
-        #     principalRay = self.path.principalRay()
-        #     axialRay = self.path.axialRay()
-        #     rayGroup = (principalRay, axialRay)
-        #     linewidth = 1.5
-        # else:
-        #     halfAngle = self.path.fanAngle / 2.0
-        #     halfHeight = self.path.objectHeight / 2.0
-        #     rayGroup = Ray.fanGroup(
-        #         yMin=-halfHeight,
-        #         yMax=halfHeight,
-        #         M=self.path.rayNumber,
-        #         radianMin=-halfAngle,
-        #         radianMax=halfAngle,
-        #         N=self.path.fanNumber)
-        #     linewidth = 0.5
         halfHeight = 25
         linewidth = 0.5
-        halfAngle = 0.3
         manyRayTraces = self.path.traceMany(rays)
 
         lines = []
@@ -583,15 +565,14 @@ class Figure:
             # FIXME: We must take the maximum y in the starting point of manyRayTraces,
             # not halfHeight
             maxStartingHeight = halfHeight # FIXME
-            binSize = 2.0 * maxStartingHeight / (len(color) - 1)
+            binSize = 2.0 * maxStartingHeight
             colorIndex = int(
                 (rayInitialHeight - (-maxStartingHeight - binSize / 2)) / binSize)
             if colorIndex < 0:
                 colorIndex = 0
-            elif colorIndex >= len(color):
-                colorIndex = len(color) - 1
+            colorIndex = colorIndex % len(colors)
 
-            line = plt.Line2D(x, y, color=color[colorIndex], linewidth=linewidth, label='ray')
+            line = plt.Line2D(x, y, color=colors[colorIndex], linewidth=linewidth, label='ray')
             lines.append(line)
 
         return lines

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -117,7 +117,7 @@ class Figure:
                         "rayColors has to be a list with 3 elements."
                 self.designParams[key] = value
 
-    def display(self, raysList=None, removeBlocked = True, filePath = None):
+    def display(self, raysList, removeBlocked = True, filePath = None):
         """ Display the optical system and trace the rays.
 
         Parameters
@@ -128,17 +128,6 @@ class Figure:
             If True, the blocked rays are removed (default=True)
 
         """
-
-        if raysList is None:
-            rays = []
-            principalRay = self.path.principalRay()
-            axialRay = self.path.axialRay()
-            if principalRay is not None:
-                rays.append(principalRay) 
-            if axialRay is not None:
-                rays.append(axialRay)
-
-            raysList = [rays]
 
         self.initializeDisplay()
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -134,7 +134,8 @@ class Figure:
         for rays in raysList:
             rayTrace = self.rayTraceLines(rays=rays, removeBlocked=removeBlocked)     
             self.drawLines(rayTrace)
-            self.drawDisplayObjects()
+
+        self.drawDisplayObjects()
 
         self.axes.callbacks.connect('ylim_changed', self.onZoomCallback)
         self.axes.set_xlim(0 - self.path.L * 0.05, self.path.L + self.path.L * 0.05)

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -145,7 +145,7 @@ class Figure:
         else:
             self._showPlot()
 
-    def displayGaussianBeam(self, beams=None, filepath=None):
+    def displayGaussianBeam(self, beams=None, filePath=None):
         """ Display the optical system and trace the laser beam.
         If comments are included they will be displayed on a
         graph in the bottom half of the plot.
@@ -165,8 +165,8 @@ class Figure:
         self.axes.set_xlim(0 - self.path.L * 0.05, self.path.L + self.path.L * 0.05)
         self.axes.set_ylim([-self.displayRange() / 2 * 1.6, self.displayRange() / 2 * 1.6])
 
-        if filepath is not None:
-            self.figure.savefig(filepath, dpi=600)
+        if filePath is not None:
+            self.figure.savefig(filePath, dpi=600)
         else:
             self._showPlot()
 

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -686,40 +686,26 @@ class ImagingPath(MatrixGroup):
 
         return super(ImagingPath, self).lagrangeInvariant(z=z, ray1=ray1, ray2=ray2)
 
-    def display(self, onlyPrincipalAndAxialRays=True,
-                removeBlockedRaysCompletely=False, comments=None,
-                limitObjectToFieldOfView=None, onlyChiefAndMarginalRays=None):
+    def display(self, rays=None, raysList=None, removeBlocked=True, comments=None, onlyPrincipalAndAxialRays=None):
         """ Display the optical system and trace the rays.
 
         Parameters
         ----------
-        limitObjectToFieldOfView : bool (Optional)
-            If True, the object will be limited to the field of view and
-            the calculated field of view will be used instead of the objectHeight (default=True)
-        onlyPrincipalAndAxialRays : bool (Optional)
-            If True, only the principal and axial rays will appear on the plot (default=True)
-        removeBlockedRaysCompletely : bool (Optional)
+        rays : `Rays` instance
+
+        raysList : list of `Rays` or list of list of `Ray`
+
+        removeBlocked : bool (Optional)
             If True, the blocked rays are removed (default=False)
         comments : string
             If comments are included they will be displayed on a graph in the bottom half of the plot. (default=None)
 
         """
-        if onlyChiefAndMarginalRays is not None:
-            warnings.warn(" Usage of onlyChiefAndMarginalRays is deprecated, "
-                          "use onlyPrincipalAndAxialRays instead.")
-            onlyPrincipalAndAxialRays = onlyChiefAndMarginalRays
-        if limitObjectToFieldOfView is not None:
-            self.figure.designParams['limitObjectToFieldOfView'] = limitObjectToFieldOfView
-
         self.figure.createFigure(title=self.label, comments=comments)
 
-        self.figure.display(onlyPrincipalAndAxialRays=onlyPrincipalAndAxialRays,
-                            removeBlockedRaysCompletely=removeBlockedRaysCompletely)
+        self.figure.display(raysList=raysList, removeBlocked=removeBlocked)
 
-    def saveFigure(self, filepath,
-                   onlyPrincipalAndAxialRays=True,
-                   removeBlockedRaysCompletely=False, comments=None,
-                   limitObjectToFieldOfView=None, onlyChiefAndMarginalRays=None):
+    def saveFigure(self, rays=None, raysList=None, removeBlocked=True, comments=None, onlyPrincipalAndAxialRays=None, filePath=None):
         """
         The figure of the imaging path can be saved using this function.
 
@@ -740,15 +726,6 @@ class ImagingPath(MatrixGroup):
             If comments are included they will be displayed on a graph in the bottom half of the plot. (default=None)
 
         """
-        if onlyChiefAndMarginalRays is not None:
-            warnings.warn(" Usage of onlyChiefAndMarginalRays is deprecated, "
-                          "use onlyPrincipalAndAxialRays instead.")
-            onlyPrincipalAndAxialRays = onlyChiefAndMarginalRays
-        if limitObjectToFieldOfView is not None:
-            self.figure.designParams['limitObjectToFieldOfView'] = limitObjectToFieldOfView
-
         self.figure.createFigure(title=self.label, comments=comments)
 
-        self.figure.display(onlyPrincipalAndAxialRays=onlyPrincipalAndAxialRays,
-                            removeBlockedRaysCompletely=removeBlockedRaysCompletely,
-                            filepath=filepath)
+        self.figure.display(raysList=raysList, removeBlocked=removeBlocked, filePath=filePath)

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -701,6 +701,22 @@ class ImagingPath(MatrixGroup):
             If comments are included they will be displayed on a graph in the bottom half of the plot. (default=None)
 
         """
+        if raysList is None:
+            raysList = []
+        if rays is not None:
+            raysList.append(rays)
+
+        if len(raysList) == 0:
+            rays = []
+            principalRay = self.principalRay()
+            axialRay = self.axialRay()
+            if principalRay is not None:
+                rays.append(principalRay) 
+            if axialRay is not None:
+                rays.append(axialRay)
+
+            raysList.append(rays)
+
         self.figure.createFigure(title=self.label, comments=comments)
 
         self.figure.display(raysList=raysList, removeBlocked=removeBlocked)
@@ -726,6 +742,22 @@ class ImagingPath(MatrixGroup):
             If comments are included they will be displayed on a graph in the bottom half of the plot. (default=None)
 
         """
+        if raysList is None:
+            raysList = []
+        if rays is not None:
+            raysList.append(rays)
+
+        if len(raysList) == 0:
+            rays = []
+            principalRay = self.principalRay()
+            axialRay = self.axialRay()
+            if principalRay is not None:
+                rays.append(principalRay) 
+            if axialRay is not None:
+                rays.append(axialRay)
+
+            raysList.append(rays)
+
         self.figure.createFigure(title=self.label, comments=comments)
 
         self.figure.display(raysList=raysList, removeBlocked=removeBlocked, filePath=filePath)

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -669,7 +669,7 @@ class Matrix(object):
 
         Parameters
         ----------
-        inputRays : object of Ray class
+        inputRays : list of object of Ray class
             A List of rays, each object includes two ray. The fisr is the properties
             of the input ray and the second is the properties of the output ray.
 
@@ -841,6 +841,35 @@ class Matrix(object):
             outputRaysList += rays.rays
 
         return Rays(rays=outputRaysList)
+
+    def traceProfiles(self, rays, z=float("+inf")):
+        rayTraces = self.traceMany(rays)
+
+        outputRays = Rays()
+        for rayTrace in rayTraces:
+            for ray in rayTrace:
+                closestRay = rayTrace[0]
+
+                for ray in rayTrace:
+                    if closestRay.isBlocked:
+                        break
+
+                    if ray.z == z:
+                        if ray.isNotBlocked:
+                            outputRays.append(ray)
+                        break
+
+                    if ray.z > z:
+                        slopeY = (ray.y-closestRay.y)/(ray.z-closestRay.z)
+                        slopeTheta = (ray.theta-closestRay.theta)/(ray.z-closestRay.z)
+                        dz = (z-closestRay.z)
+                        closestRay.y += dz * slopeY
+                        closestRay.theta += dz * slopeTheta
+                        outputRays.append(closestRay)
+                        break
+                    closestRay = ray
+
+        return outputRays
 
     @property
     def isImaging(self):

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -842,32 +842,12 @@ class Matrix(object):
 
         return Rays(rays=outputRaysList)
 
-    def traceProfiles(self, rays, z=float("+inf")):
-        rayTraces = self.traceMany(rays)
-
+    def profileFromRayTraces(self, rayTraces, z=float("+inf")):
         outputRays = Rays()
         for rayTrace in rayTraces:
-            for ray in rayTrace:
-                closestRay = rayTrace[0]
-
-                for ray in rayTrace:
-                    if closestRay.isBlocked:
-                        break
-
-                    if ray.z == z:
-                        if ray.isNotBlocked:
-                            outputRays.append(ray)
-                        break
-
-                    if ray.z > z:
-                        slopeY = (ray.y-closestRay.y)/(ray.z-closestRay.z)
-                        slopeTheta = (ray.theta-closestRay.theta)/(ray.z-closestRay.z)
-                        dz = (z-closestRay.z)
-                        closestRay.y += dz * slopeY
-                        closestRay.theta += dz * slopeTheta
-                        outputRays.append(closestRay)
-                        break
-                    closestRay = ray
+            ray = Ray.alongTrace(rayTrace, z=z)
+            if ray.isNotBlocked:
+                outputRays.append(ray)
 
         return outputRays
 

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -845,7 +845,7 @@ class Matrix(object):
     def profileFromRayTraces(self, rayTraces, z=float("+inf")):
         outputRays = Rays()
         for rayTrace in rayTraces:
-            ray = Ray.alongTrace(rayTrace, z=z)
+            ray = Ray.along(rayTrace, z=z)
             if ray.isNotBlocked:
                 outputRays.append(ray)
 

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -435,7 +435,7 @@ class MatrixGroup(Matrix):
 
         """
         if not isinstance(inputRay, (Ray, GaussianBeam)):
-            raise TypeError("'inputRay' must be a Ray or a GaussianBeam.")
+            raise TypeError("'inputRay' must be a Ray or a GaussianBeam {0}".format(inputRay))
         ray = inputRay
         if ray != self._lastRayToBeTraced:
             rayTrace = [ray]

--- a/raytracing/ray.py
+++ b/raytracing/ray.py
@@ -174,6 +174,86 @@ class Ray:
 
         return rays
 
+    @staticmethod
+    def along(ray1, ray2, z):
+        """This function returns a ray at position z using the line defined
+        by ray1 and ray2.  y and theta are linearly interpolated.
+
+        Parameters
+        ----------
+        ray1 : Ray
+            First ray
+        ray2 : Ray
+            Second ray
+        z : float
+            Position in z where we want the output ray
+
+        Returns
+        -------
+        ray : an interpolated Ray 
+            A Ray at position z, with y and theta interpolated from ray1 and ray2
+
+        Notes
+        -----
+        If the first ray is blocked, then None is returned
+
+        See Also
+        --------
+        raytracing.Ray.alongTrace()
+
+        """
+        distance = ray2.z-ray1.z
+        if ray1.isBlocked:
+            return None
+
+        if distance > 0:
+            slopeY = (ray2.y-ray1.y)/distance
+            slopeTheta = (ray2.theta-ray1.theta)/distance
+            dz = (z-ray1.z)
+            return Ray(y=ray1.y + dz * slopeY, theta=ray1.theta + dz * slopeTheta, z=z)
+        else:
+            return ray1
+
+    @staticmethod
+    def alongTrace(rayTrace, z):
+        """This function returns a ray at position z along the ray trace. 
+        y and theta are linearly interpolated in between the two closest rays.
+
+        Parameters
+        ----------
+        rayTrace : list of Ray
+            The rayTrace
+        z : float
+            Position in z where we want the output ray
+
+        Returns
+        -------
+        ray : an interpolated Ray 
+            A Ray at position z, with y and theta interpolated from the ray trace
+
+        Notes
+        -----
+        If the ray at an earlier z is blocked, then None is returned
+
+        See Also
+        --------
+        raytracing.Ray.along()
+
+        """
+        closestRay = rayTrace[0]
+        for ray in rayTrace:
+            if closestRay.isBlocked:
+                return None
+
+            if ray.z == z:
+                if ray.isNotBlocked:
+                    return ray
+
+            if ray.z > z:
+                return Ray.along(ray1=closestRay,ray2=ray, z=z)
+            closestRay = ray
+
+
     def __str__(self):
         """String description that allows the use of print(Ray())."""
 

--- a/raytracing/ray.py
+++ b/raytracing/ray.py
@@ -174,14 +174,12 @@ class Ray:
 
         return rays
 
-    @staticmethod
-    def along(ray, z):
-        """This function returns a ray at position z parallel to the provided ray
+    def at(self, z):
+        """This function returns a ray at position z parallel to the current ray.
+        Z is not the distance, it is the position.  The distance is (z-self.z) 
 
         Parameters
         ----------
-        ray : Ray
-            The ray to which the output ray is parallel
         z : float
             Position in z where we want the output ray
 
@@ -196,16 +194,16 @@ class Ray:
 
         See Also
         --------
-        raytracing.Ray.alongTrace()
+        raytracing.Ray.along()
 
         """
-        outputRay = Ray(y=ray.y + (z-ray.z) * ray.theta, theta=ray.theta, z=z)
-        if ray.isBlocked:
+        outputRay = Ray(y=self.y + (z-self.z) * self.theta, theta=self.theta, z=z)
+        if self.isBlocked:
             outputRay.isBlocked = True
         return outputRay
 
     @staticmethod
-    def alongTrace(rayTrace, z):
+    def along(rayTrace, z):
         """This function returns a ray at position z along the ray trace. 
         y and theta are linearly interpolated in between the two closest rays.
 
@@ -236,7 +234,7 @@ class Ray:
                 return ray
 
             if ray.z > z:
-                return Ray.along(ray=closestRay, z=z)
+                return closestRay.at(z=z)
 
             closestRay = ray
 

--- a/raytracing/ray.py
+++ b/raytracing/ray.py
@@ -175,44 +175,34 @@ class Ray:
         return rays
 
     @staticmethod
-    def along(ray1, ray2, z):
-        """This function returns a ray at position z using the line defined
-        by ray1 and ray2.  y and theta are linearly interpolated.
+    def along(ray, z):
+        """This function returns a ray at position z parallel to the provided ray
 
         Parameters
         ----------
-        ray1 : Ray
-            First ray
-        ray2 : Ray
-            Second ray
+        ray : Ray
+            The ray to which the output ray is parallel
         z : float
             Position in z where we want the output ray
 
         Returns
         -------
         ray : an interpolated Ray 
-            A Ray at position z, with y and theta interpolated from ray1 and ray2
+            A Ray at position z, with y interpolated and theta unchanged
 
         Notes
         -----
-        If the first ray is blocked, then None is returned
+        If ray is blocked, then the output Ray will be blocked too
 
         See Also
         --------
         raytracing.Ray.alongTrace()
 
         """
-        distance = ray2.z-ray1.z
-        if ray1.isBlocked:
-            return None
-
-        if distance > 0:
-            slopeY = (ray2.y-ray1.y)/distance
-            slopeTheta = (ray2.theta-ray1.theta)/distance
-            dz = (z-ray1.z)
-            return Ray(y=ray1.y + dz * slopeY, theta=ray1.theta + dz * slopeTheta, z=z)
-        else:
-            return ray1
+        outputRay = Ray(y=ray.y + (z-ray.z) * ray.theta, theta=ray.theta, z=z)
+        if ray.isBlocked:
+            outputRay.isBlocked = True
+        return outputRay
 
     @staticmethod
     def alongTrace(rayTrace, z):
@@ -233,7 +223,7 @@ class Ray:
 
         Notes
         -----
-        If the ray at an earlier z is blocked, then None is returned
+        If the ray at an earlier z is blocked, then the Ray will be blocked too
 
         See Also
         --------
@@ -242,17 +232,15 @@ class Ray:
         """
         closestRay = rayTrace[0]
         for ray in rayTrace:
-            if closestRay.isBlocked:
-                return None
-
             if ray.z == z:
-                if ray.isNotBlocked:
-                    return ray
+                return ray
 
             if ray.z > z:
-                return Ray.along(ray1=closestRay,ray2=ray, z=z)
+                return Ray.along(ray=closestRay, z=z)
+
             closestRay = ray
 
+        return rayTrace[-1]
 
     def __str__(self):
         """String description that allows the use of print(Ray())."""

--- a/raytracing/ray.py
+++ b/raytracing/ray.py
@@ -225,7 +225,7 @@ class Ray:
 
         See Also
         --------
-        raytracing.Ray.along()
+        raytracing.Ray.at()
 
         """
         closestRay = rayTrace[0]

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -770,10 +770,10 @@ class RandomLambertianRays(RandomRays):
 
 class ObjectRays(UniformRays):
     def __init__(self, diameter, halfAngle=1.0, H=3, T=3):
-        super(UniformRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=halfAngle, thetaMin=-halfAngle, M=H, N=T)
+        super(ObjectRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=halfAngle, thetaMin=-halfAngle, M=H, N=T)
 
 class LampRays(RandomUniformRays):
     def __init__(self, diameter, NA=1.0, N=10000):
-        super(RandomUniformRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=NA, thetaMin=-NA, maxCount=N)
+        super(LampRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=NA, thetaMin=-NA, maxCount=N)
 
 

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -528,7 +528,6 @@ class UniformRays(Rays):
                 rays.append(Ray(y, theta))
         super(UniformRays, self).__init__(rays=rays)
 
-
 class LambertianRays(Rays):
     """A list of rays with Lambertian distribution.
 
@@ -768,3 +767,13 @@ class RandomLambertianRays(RandomRays):
         ray = Ray(y, theta)
         self.append(ray)
         return ray
+
+class ObjectRays(UniformRays):
+    def __init__(self, diameter, halfAngle=1.0, H=3, T=3):
+        super(UniformRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=halfAngle, thetaMin=-halfAngle, M=H, N=T)
+
+class LampRays(RandomUniformRays):
+    def __init__(self, diameter, NA=1.0, N=10000):
+        super(RandomUniformRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=NA, thetaMin=-NA, maxCount=N)
+
+

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -158,21 +158,21 @@ class TestImagingPath(envtest.RaytracingTestCase):
         self.assertAlmostEqual(path.imageSize(), imgSize, 2)
 
     def testSave(self):
-        filename = self.tempFilePath("test.png")
+        filePath = self.tempFilePath("test.png")
         comments = "This is a test"
         path = ImagingPath(System4f(10, 10, 10, 10))
-        path.saveFigure(filename, comments=comments)
-        if not os.path.exists(filename):
+        path.saveFigure(filePath=filePath, comments=comments)
+        if not os.path.exists(filePath):
             self.fail("No file saved (with comments)")
-        os.remove(filename)
+        os.remove(filePath)
 
     def testSaveWithoutComments(self):
-        filename = self.tempFilePath("test.png")
+        filePath = self.tempFilePath("test.png")
         path = ImagingPath(System4f(10, 10, 10, 10))
-        path.saveFigure(filename)
-        if not os.path.exists(filename):
+        path.saveFigure(filePath=filePath)
+        if not os.path.exists(filePath):
             self.fail("No file saved (without comments)")
-        os.remove(filename)
+        os.remove(filePath)
 
     def testChiefRayNoApertureStop(self):
         path = ImagingPath(System2f(10))

--- a/raytracing/tests/testsRay.py
+++ b/raytracing/tests/testsRay.py
@@ -102,6 +102,38 @@ class TestRay(envtest.RaytracingTestCase):
         other = Ray(10, 10)
         self.assertEqual(ray, other)
 
+    def testRayParallelToAnotherRay(self):
+        ray = Ray(0,0).at(z=1)
+        self.assertEqual(ray, Ray(0,0))
+
+        ray = Ray(0,0.1).at(z=1)
+        self.assertEqual(ray, Ray(0.1, 0.1))
+
+        ray = Ray(0,0.1).at(z=-1)
+        self.assertEqual(ray, Ray(-0.1, 0.1))
+
+        ray = Ray(1,0.1).at(z=1)
+        self.assertEqual(ray, Ray(1.1,0.1))
+
+        ray = Ray(-1,0.1).at(z=1)
+        self.assertEqual(ray, Ray(-0.9, 0.1))
+
+        ray = Ray(-1,0.1).at(z=-1)
+        self.assertEqual(ray, Ray(-1.1, 0.1))
+
+        ray = Ray(-1,0.1,z=1).at(z=1)
+        self.assertEqual(ray, Ray(-1.0, 0.1))
+
+    def testRayTrace(self):
+        rayTrace = [Ray(0,0.1), Ray(0.1,0.2,z=1), Ray(0.3,0,z=2)]
+
+        self.assertEqual(Ray.along(rayTrace, z=0), Ray(0,0.1))
+        self.assertEqual(Ray.along(rayTrace, z=0.5), Ray(0.05,0.1))
+        self.assertEqual(Ray.along(rayTrace, z=1.0).y, 0.1)
+        self.assertEqual(Ray.along(rayTrace, z=1.0), Ray(0.1,0.2))
+        self.assertEqual(Ray.along(rayTrace, z=1.5), Ray(0.2,0.2))
+        self.assertEqual(Ray.along(rayTrace, z=2.0), Ray(0.3,0))
+
 
 if __name__ == '__main__':
     envtest.main()


### PR DESCRIPTION
The method `display()` now accepts `rays` and/or `raysList` as argument. If nothing is provided, principal and axial rays are used.

Also, `ObjectRays` and `LampRays` have been created, to match the user nomenclature and for convenience.