### PR TITLE
Deprecated decorator

### DIFF
--- a/raytracing/ray.py
+++ b/raytracing/ray.py
@@ -1,4 +1,5 @@
 import warnings
+from .utils import deprecated
 
 
 class Ray:
@@ -63,6 +64,8 @@ class Ray:
         return not self.isBlocked
 
     @staticmethod
+    @deprecated("The creation of a group of rays with this method is deprecated. Usage of the class Rays and its "
+                "subclasses is recommended.")
     def fan(y: float, radianMin: float, radianMax: float, N: int):
         """This function generates a list of rays spanning from radianMin to radianMax.
         This is usually used with Matrix.trace() or Matrix.traceMany() to trace the rays
@@ -94,8 +97,6 @@ class Ray:
         raytracing.Matrix.traceMany().
 
         """
-        warnings.warn("The creation of a group of rays with this method is deprecated. Usage of the class Rays and its "
-                      "subclasses is recommended.", DeprecationWarning)
 
         if N >= 2:
             deltaRadian = float(radianMax - radianMin) / (N - 1)
@@ -112,6 +113,8 @@ class Ray:
         return rays
 
     @staticmethod
+    @deprecated("The creation of a group of rays with this method is deprecated. Usage of the class Rays and its "
+                "subclasses is recommended.")
     def fanGroup(yMin: float, yMax: float, M: int, radianMin: float, radianMax: float, N: int):
         """This function creates a list of rays spanning from yMin to yMax and radianMin to radianMax.
         This is usually used with Matrix.trace() or Matrix.traceMany() to trace the rays
@@ -148,8 +151,6 @@ class Ray:
         raytracing.Matrix.traceMany().
 
         """
-        warnings.warn("The creation of a group of rays with this method is deprecated. Usage of the class Rays and its"
-                      "subclasses is recommended.", DeprecationWarning)
 
         if N >= 2:
             deltaRadian = float(radianMax - radianMin) / (N - 1)

--- a/raytracing/tests/testsDecorators.py
+++ b/raytracing/tests/testsDecorators.py
@@ -1,4 +1,5 @@
 import envtest
+from raytracing.utils import deprecated
 
 
 def simpleDecoratorReturnsTuple(func):
@@ -33,3 +34,19 @@ class TestDecorators(envtest.RaytracingTestCase):
             return a, b, c
 
         self.assertTupleEqual(toto(1, 2, 3), (0, (1, 2, 3)))
+
+
+class TestDeprecatedDecorator(envtest.RaytracingTestCase):
+
+    def testDeprecated(self):
+        reason = "This is deprecated because it is a test."
+
+        @deprecated(reason)
+        def deprecatedFunction():
+            return "This is deprecated"
+
+        with self.assertWarns(DeprecationWarning) as deprec:
+            retVal = deprecatedFunction()
+
+        self.assertEqual(retVal, "This is deprecated")
+        self.assertEqual(str(deprec.warning), reason)

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 """ Two constants: deg and rad to quickly convert to degrees
 or radians with angle*degPerRad or angle*radPerDeg """
@@ -32,3 +33,14 @@ def areAbsolutelyNotEqual(left, right, epsilon=1e-3):
 
 def areRelativelyNotEqual(left, right, epsilon=1e-3):
     return not areRelativelyAlmostEqual(left, right, epsilon)
+
+
+def deprecated(reason: str):
+    def deprecatedFunc(func):
+        def wrapper(*args, **kwargs):
+            warnings.warn(reason, DeprecationWarning)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return deprecatedFunc


### PR DESCRIPTION
Typing `warnings.warn("This is the message to show when we use a deprecation warning", DeprecationWarning)` can be annoying especially when we have multiple functions or methods to do. That is why I implemented a deprecation decorator in `utils.py`. I think that as `Raytracing` is living, there will be some modifications, improvements, etc. that can lead to deprecated stuff (like in `ImaginPath` or `Ray` with `fan`) and just deleting the now *useless* stuff is not a good idea for API compatibility.

This decorator is very simple. Example:
````python
@deprecated("This is the reason this function is deprecated")
def deprecatedFunc():
    return "I am deprecated"
````