### PR TITLE
Fix graphics of matrix group subclasses

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -127,7 +127,9 @@ class Figure:
         z = 0
         for element in self.path.elements:
             graphic = GraphicOf(element, x=z, minSize=maxRayHeight)
-            if graphic is not None:
+            if type(graphic) is list:  # MatrixGroup creates stand-alone graphics for now
+                graphics.extend(graphic)
+            elif graphic is not None:
                 graphics.append(graphic)
             z += element.L
         return graphics

--- a/raytracing/graphics.py
+++ b/raytracing/graphics.py
@@ -284,16 +284,20 @@ class MatrixGroupGraphic(MatrixGraphic):
 
     @property
     def components(self):
-        components = []
+        if self._components is None:
+            self._components = self.mainComponents
+        return self._components
+
+    @property
+    def standAloneGraphics(self):
+        graphics = []
         z = 0
         for element in self.matrixGroup.elements:
-            graphic = GraphicOf(element, x=z)
-            # fixme: all components are defined at z=0 anyways,
-            #  should take a group of graphics instead ?
+            graphic = GraphicOf(element, x=z + self.x)
             if graphic is not None:
-                components.extend(graphic.components)
+                graphics.append(graphic)
             z += element.L
-        return components
+        return graphics
 
     @property
     def pointsOfInterest(self):
@@ -387,11 +391,10 @@ class ObjectiveGraphic(MatrixGroupGraphic):
 
 
 class GraphicOf:
-    def __new__(cls, element, x=0.0, minSize=0) -> Union[MatrixGraphic, None]:
+    def __new__(cls, element, x=0.0, minSize=0) -> Union[MatrixGraphic, None, list]:
         instance = type(element).__name__
         if type(element) is Objective or issubclass(type(element), Objective):
             return ObjectiveGraphic(element, x=x)
-
         if instance is 'Lens':
             return LensGraphic(element, x=x, minSize=minSize)
         if instance is 'Space':
@@ -401,6 +404,6 @@ class GraphicOf:
         if element.surfaces:
             return SurfacesGraphic(element, x=x)
         if issubclass(type(element), MatrixGroup):
-            return MatrixGroupGraphic(element, x=x)
+            return MatrixGroupGraphic(element, x=x).standAloneGraphics
         else:
             return MatrixGraphic(element, x=x)

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -35,19 +35,6 @@ class MatrixGroup(Matrix):
         self._lastRayToBeTraced = None
         self._lastRayTrace = None
 
-    @property
-    def surfaces(self):
-        """ A list of interfaces that represents the element for drawing purposes 
-
-        We combine all interfaces into a single list of interfaces
-        """
-
-        allSurfaces = []
-        for element in self.elements:
-            allSurfaces.extend(element.surfaces)
-
-        return allSurfaces
-
     def append(self, matrix):
         r"""This function adds an element at the end of the path.
 


### PR DESCRIPTION
Fix the display of MatrixGroup (System4f, System2f, etc).
Ended up turning down the MatrixGroupGraphic instance for now, I am just asking for a list of Graphic instances for all its elements instead. This is an easy solution/hack for now, but I will look to implement a proper MatrixGroupGraphic soon when I have the time. 