### PR TITLE
Enable the display of multiple objects at desired positions

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -580,7 +580,7 @@ class MplFigure(Figure):
         plt.connect('resize_event', self.onZoomCallback)
 
         if interactive:
-            plt.subplots_adjust(right=0.82)
+            plt.subplots_adjust(right=0.81)
             self.initVisibilityCheckBoxes()
 
         if filepath is not None:
@@ -645,7 +645,7 @@ class MplFigure(Figure):
         visibility = self.visibility
         visibility.pop('Elements')
 
-        subAxes = plt.axes([0.82, 0.4, 0.1, 0.5], frameon=False, anchor='NW')
+        subAxes = plt.axes([0.81, 0.4, 0.1, 0.5], frameon=False, anchor='NW')
         self.checkBoxes = CheckButtons(subAxes, visibility.keys(), visibility.values())
 
         step = 0.15

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -175,7 +175,7 @@ class Figure:
             instance = type(rays).__name__
             # todo: enable multiple instances
             if instance is 'ObjectRays':
-                self.graphicGroups['Object/Image'].append(ObjectGraphic(rays.yMax * 2, x=rays._z))  # todo: object position
+                self.graphicGroups['Object/Image'].append(ObjectGraphic(rays.yMax * 2, x=rays._z))
                 self.graphicGroups['Object/Image'].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays._z))
             if instance is 'LampRays':
                 self.graphicGroups['Lamp'].append(LampGraphic(rays.yMax * 2, x=0))
@@ -204,7 +204,7 @@ class Figure:
 
         for (position, magnification) in planeInfo:
             planeGraphics.append(ImageGraphic(diameter=magnification * objectDiameter,
-                                              x=position, fill=fill, color=color))
+                                              x=position + x, fill=fill, color=color))
         return planeGraphics
 
     @property

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -173,10 +173,13 @@ class Figure:
     def setGraphicsFromRaysList(self):
         for rays in self.raysList:
             instance = type(rays).__name__
-            # todo: enable multiple instances
             if instance is 'ObjectRays':
-                self.graphicGroups['Object/Image'].append(ObjectGraphic(rays.yMax * 2, x=rays._z))
-                self.graphicGroups['Object/Image'].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays._z))
+                if rays._z == 0:
+                    self.graphicGroups['Object/Image'].append(ObjectGraphic(rays.yMax * 2))
+                    self.graphicGroups['Object/Image'].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2))
+                else:
+                    self.graphicGroups['Object/Image (z={})'.format(rays._z)] = [ObjectGraphic(rays.yMax * 2, x=rays._z)]
+                    self.graphicGroups['Object/Image (z={})'.format(rays._z)].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays._z))
             if instance is 'LampRays':
                 self.graphicGroups['Lamp'].append(LampGraphic(rays.yMax * 2, x=0))
 
@@ -186,7 +189,10 @@ class Figure:
 
             instance = type(rays).__name__
             if instance is 'ObjectRays':
-                self.lineGroups['Object/Image'].extend(rayTrace)
+                if rays._z == 0:
+                    self.lineGroups['Object/Image'].extend(rayTrace)
+                else:
+                    self.lineGroups['Object/Image (z={})'.format(rays._z)] = rayTrace
             elif instance is 'LampRays':
                 self.designParams['showObjectImage'] = False
                 self.lineGroups['Lamp'].extend(rayTrace)

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -174,12 +174,9 @@ class Figure:
         for rays in self.raysList:
             instance = type(rays).__name__
             if instance is 'ObjectRays':
-                if rays._z == 0:
-                    self.graphicGroups['Object/Image'].append(ObjectGraphic(rays.yMax * 2))
-                    self.graphicGroups['Object/Image'].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2))
-                else:
-                    self.graphicGroups['Object/Image (z={})'.format(rays._z)] = [ObjectGraphic(rays.yMax * 2, x=rays._z)]
-                    self.graphicGroups['Object/Image (z={})'.format(rays._z)].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays._z))
+                objectKey = 'Object/Image (z={})'.format(rays._z) if rays._z != 0 else 'Object/Image'
+                self.graphicGroups[objectKey] = [ObjectGraphic(rays.yMax * 2, x=rays._z)]
+                self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays._z))
             if instance is 'LampRays':
                 self.graphicGroups['Lamp'].append(LampGraphic(rays.yMax * 2, x=0))
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -340,8 +340,16 @@ class Figure:
                 dz = rays._z
 
         if dz != 0:
-            subPath = self.path.subPath(zStart=dz)
-            manyRayTraces = subPath.traceMany(rays)
+            forwardPath = self.path.subPath(zStart=dz)
+            backwardPath = self.path.subPath(zStart=dz, backwards=True)
+
+            forwardRayTraces = forwardPath.traceMany(rays)
+            backwardRayTraces = backwardPath.traceMany(rays)
+            for rayTrace in backwardRayTraces:
+                for ray in rayTrace:
+                    ray.z = -abs(ray.z)
+            manyRayTraces = forwardRayTraces
+            manyRayTraces.extend(backwardRayTraces)
         else:
             manyRayTraces = self.path.traceMany(rays)
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -332,10 +332,12 @@ class Figure:
         """
 
         linewidth = 0.5
+        colors = self.designParams['rayColors']
         if type(rays).__name__ is 'LampRays':
             colors = self.designParams['lampRayColors']
-        else:
-            colors = self.designParams['rayColors']
+        elif type(rays).__name__ is 'ObjectRays':
+            if rays.rayColors is not None:
+                colors = rays.rayColors
 
         dz = 0
         if type(rays) is not list:

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -200,12 +200,18 @@ class Figure:
 
     def graphicsOfConjugatePlanes(self, objectDiameter, fill=True, color='r', x=0):
         planeGraphics = []
-        if x != 0:
-            planeInfo = self.path.subPath(zStart=x).intermediateConjugates()
-        else:
-            planeInfo = self.path.intermediateConjugates()
 
-        for (position, magnification) in planeInfo:
+        if x != 0:
+            planeConjugates = self.path.subPath(zStart=x).intermediateConjugates()
+            backwardConjugates = self.path.subPath(zStart=x, backwards=True).intermediateConjugates()
+            for backConjugate in backwardConjugates:
+                backConjugate[0] *= -1
+            planeConjugates.extend(backwardConjugates)
+
+        else:
+            planeConjugates = self.path.intermediateConjugates()
+
+        for (position, magnification) in planeConjugates:
             planeGraphics.append(ImageGraphic(diameter=magnification * objectDiameter,
                                               x=position + x, fill=fill, color=color))
         return planeGraphics

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -6,6 +6,11 @@ import itertools
 import warnings
 import sys
 
+""" Graphics key constants """
+kPrincipalKey = "Principal/axial rays"
+kObjectImageKey = "Object/Image"
+kLampKey = "Lamp"
+kElementsKey = "Elements"
 
 class Figure:
     """Base class to contain the required objects of a figure.

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -174,9 +174,9 @@ class Figure:
         for rays in self.raysList:
             instance = type(rays).__name__
             if instance is 'ObjectRays':
-                objectKey = 'Object/Image (z={})'.format(rays._z) if rays._z != 0 else 'Object/Image'
-                self.graphicGroups[objectKey] = [ObjectGraphic(rays.yMax * 2, x=rays._z)]
-                self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays._z))
+                objectKey = 'Object/Image (z={})'.format(rays.z) if rays.z != 0 else 'Object/Image'
+                self.graphicGroups[objectKey] = [ObjectGraphic(rays.yMax * 2, x=rays.z)]
+                self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays.z))
             if instance is 'LampRays':
                 self.graphicGroups['Lamp'].append(LampGraphic(rays.yMax * 2, x=0))
 
@@ -186,10 +186,10 @@ class Figure:
 
             instance = type(rays).__name__
             if instance is 'ObjectRays':
-                if rays._z == 0:
+                if rays.z == 0:
                     self.lineGroups['Object/Image'].extend(rayTrace)
                 else:
-                    self.lineGroups['Object/Image (z={})'.format(rays._z)] = rayTrace
+                    self.lineGroups['Object/Image (z={})'.format(rays.z)] = rayTrace
             elif instance is 'LampRays':
                 self.designParams['showObjectImage'] = False
                 self.lineGroups['Lamp'].extend(rayTrace)
@@ -339,8 +339,8 @@ class Figure:
 
         dz = 0
         if type(rays) is not list:
-            if rays._z != 0:
-                dz = rays._z
+            if rays.z != 0:
+                dz = rays.z
 
         if dz != 0:
             forwardPath = self.path.subPath(zStart=dz)

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -337,7 +337,6 @@ class Figure:
         2. the principal and axial rays.
         """
 
-        linewidth = 0.5
         colors = self.designParams['rayColors']
         if type(rays).__name__ is 'LampRays':
             colors = self.designParams['lampRayColors']
@@ -386,7 +385,7 @@ class Figure:
                     (y[0] + maxHeight) / (maxHeight * 2) * (len(colors) - 1)))
                 colorIndex = colorIndex % len(colors)
 
-            line = Line(np.asarray(x) + dz, y, color=colors[colorIndex], lineWidth=linewidth, label='ray')
+            line = Line(np.asarray(x) + dz, y, color=colors[colorIndex], lineWidth=lineWidth, label='ray')
             lines.append(line)
 
         return lines

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -175,8 +175,13 @@ class Figure:
             instance = type(rays).__name__
             if instance is 'ObjectRays':
                 objectKey = 'Object/Image (z={})'.format(rays.z) if rays.z != 0 else 'Object/Image'
-                self.graphicGroups[objectKey] = [ObjectGraphic(rays.yMax * 2, x=rays.z)]
-                self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays.z))
+                color = 'b' if rays.color is None else rays.color
+                self.graphicGroups[objectKey] = [ObjectGraphic(rays.yMax * 2, x=rays.z, color=color)]
+                if rays.color is None:
+                    self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays.z))
+                else:
+                    self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays.z,
+                                                                                        fill=False, color=color))
             if instance is 'LampRays':
                 self.graphicGroups['Lamp'].append(LampGraphic(rays.yMax * 2, x=0))
 

--- a/raytracing/graphicComponents.py
+++ b/raytracing/graphicComponents.py
@@ -139,8 +139,8 @@ class Arrow(Component):
         Starting point in y-axis where the base of the arrow sits. Defaults to 0.
     """
 
-    def __init__(self, dy: float, y=0.0, color='k', width=0.002, headLengthRatio=0.1, fill=True):
-        super(Arrow, self).__init__(color=color, hasFixedWidth=False, fill=fill)
+    def __init__(self, dy: float, y=0.0, color='k', width=0.002, headLengthRatio=0.1, fill=True, lineStyle='-'):
+        super(Arrow, self).__init__(color=color, hasFixedWidth=False, fill=fill, lineStyle=lineStyle, lineWidth=0.5)
         self.dy = dy
         self.y = y
         self.width = width

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -846,7 +846,7 @@ class ImagingPath(MatrixGroup):
 
     def subPath(self, zStart: float, backwards=False):
         """ Secondary ImagingPath defined from a desired zStart to the end of current path
-        or to the start of current path if 'inverse' is True. Used internally to trace rays
+        or to the start of current path if 'backwards' is True. Used internally to trace rays
         from different positions. """
 
         z = 0

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -909,7 +909,8 @@ class ImagingPath(MatrixGroup):
                                   'Using default ObjectRays.')
 
         if 'ObjectRays' not in [type(rays).__name__ for rays in raysList]:
-            defaultObject = ObjectRays(self.objectHeight, halfAngle=self.fanAngle, T=self.rayNumber)
+            defaultObject = ObjectRays(self.objectHeight, z=self.objectPosition,
+                                       halfAngle=self.fanAngle, T=self.rayNumber)
             raysList.append(defaultObject)
         else:
             self.figure.designParams['showObjectImage'] = True

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -844,15 +844,25 @@ class ImagingPath(MatrixGroup):
         axis1.legend(loc="upper right")
         plt.show()
 
-    def subPath(self, zStart: float):
+    def subPath(self, zStart: float, backwards=False):
+        """ Secondary ImagingPath defined from a desired zStart to the end of current path
+        or to the start of current path if 'inverse' is True. Used internally to trace rays
+        from different positions. """
+
         z = 0
         for i, element in enumerate(self.elements):
             if z < zStart < z + element.L:
                 assert type(element).__name__ is 'Space', 'The position of the rays cannot be in the same ' \
                                                           'position of another element.'
-                newElements = [Space(z + element.L - zStart)]
-                newElements.extend(self.elements[i+1:])
-                return ImagingPath(elements=newElements)
+                if backwards:
+                    newElements = [Space(zStart - z)]
+                    newElements.extend(self.elements[i-1::-1])
+                    return ImagingPath(elements=newElements)
+                else:
+                    newElements = [Space(z + element.L - zStart)]
+                    newElements.extend(self.elements[i+1:])
+                    return ImagingPath(elements=newElements)
+
             z += element.L
 
         raise ValueError('The position of the rays does not fit in any spaces.')

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -856,7 +856,8 @@ class ImagingPath(MatrixGroup):
                                                           'position of another element.'
                 if backwards:
                     newElements = [Space(zStart - z)]
-                    newElements.extend(self.elements[i-1::-1])
+                    if i != 0:
+                        newElements.extend(self.elements[i-1::-1])
                     return ImagingPath(elements=newElements)
                 else:
                     newElements = [Space(z + element.L - zStart)]

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -943,7 +943,7 @@ class ImagingPath(MatrixGroup):
                      limitObjectToFieldOfView=limitObjectToFieldOfView,
                      interactive=False, filePath=filePath)
 
-    def displayWithObject(self, diameter, fanAngle=0.1, fanNumber=3, rayNumber=3, removeBlocked=True, comments=None):
+    def displayWithObject(self, diameter, z=0, fanAngle=0.1, fanNumber=3, rayNumber=3, removeBlocked=True, comments=None):
         """ Display the optical system and trace the rays.
 
         Parameters
@@ -957,7 +957,7 @@ class ImagingPath(MatrixGroup):
         """
 
         self._objectHeight = diameter
-        rays = ObjectRays(diameter, halfAngle=fanAngle, H=fanNumber, T=rayNumber)
+        rays = ObjectRays(diameter, halfAngle=fanAngle, H=fanNumber, T=rayNumber, z=z)
 
         self.display(rays=rays, raysList=None, removeBlocked=removeBlocked, comments=comments,
                      onlyPrincipalAndAxialRays=False,

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -844,6 +844,19 @@ class ImagingPath(MatrixGroup):
         axis1.legend(loc="upper right")
         plt.show()
 
+    def subPath(self, zStart: float):
+        z = 0
+        for i, element in enumerate(self.elements):
+            if z < zStart < z + element.L:
+                assert type(element).__name__ is 'Space', 'The position of the rays cannot be in the same ' \
+                                                          'position of another element.'
+                newElements = [Space(z + element.L - zStart)]
+                newElements.extend(self.elements[i+1:])
+                return ImagingPath(elements=newElements)
+            z += element.L
+
+        raise ValueError('The position of the rays does not fit in any spaces.')
+
     def display(self, rays=None, raysList=None, removeBlocked=True, comments=None,
                 onlyPrincipalAndAxialRays=None, limitObjectToFieldOfView=None, interactive=True, filePath=None):
         """ Display the optical system and trace the rays.

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -73,6 +73,7 @@ class Rays:
 
         self.iteration = 0
         self.progressLog = 10000
+        self._z = 0
 
         # We cache these because they can be lengthy to calculate
         self._yValues = None
@@ -766,8 +767,9 @@ class RandomLambertianRays(RandomRays):
         return ray
 
 class ObjectRays(UniformRays):
-    def __init__(self, diameter, halfAngle=1.0, H=3, T=3):
+    def __init__(self, diameter, halfAngle=1.0, H=3, T=3, z=0):
         super(ObjectRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=halfAngle, thetaMin=-halfAngle, M=H, N=T)
+        self._z = z
 
 class LampRays(RandomUniformRays):
     def __init__(self, diameter, NA=1.0, N=10000):

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -767,10 +767,11 @@ class RandomLambertianRays(RandomRays):
         return ray
 
 class ObjectRays(UniformRays):
-    def __init__(self, diameter, halfAngle=1.0, H=3, T=3, z=0, rayColors=None):
+    def __init__(self, diameter, halfAngle=1.0, H=3, T=3, z=0, rayColors=None, color=None):
         super(ObjectRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=halfAngle, thetaMin=-halfAngle, M=H, N=T)
         self.z = z
         self.rayColors = rayColors
+        self.color = color
 
 class LampRays(RandomUniformRays):
     def __init__(self, diameter, NA=1.0, N=10000):

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -73,7 +73,7 @@ class Rays:
 
         self.iteration = 0
         self.progressLog = 10000
-        self._z = 0
+        self.z = 0
 
         # We cache these because they can be lengthy to calculate
         self._yValues = None
@@ -769,7 +769,7 @@ class RandomLambertianRays(RandomRays):
 class ObjectRays(UniformRays):
     def __init__(self, diameter, halfAngle=1.0, H=3, T=3, z=0):
         super(ObjectRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=halfAngle, thetaMin=-halfAngle, M=H, N=T)
-        self._z = z
+        self.z = z
 
 class LampRays(RandomUniformRays):
     def __init__(self, diameter, NA=1.0, N=10000):

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -767,9 +767,10 @@ class RandomLambertianRays(RandomRays):
         return ray
 
 class ObjectRays(UniformRays):
-    def __init__(self, diameter, halfAngle=1.0, H=3, T=3, z=0):
+    def __init__(self, diameter, halfAngle=1.0, H=3, T=3, z=0, rayColors=None):
         super(ObjectRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=halfAngle, thetaMin=-halfAngle, M=H, N=T)
         self.z = z
+        self.rayColors = rayColors
 
 class LampRays(RandomUniformRays):
     def __init__(self, diameter, NA=1.0, N=10000):


### PR DESCRIPTION
### Changes
- added ImagingPath.subPath(zStart, backwards=False) method to get secondary paths for the tracing of rays
- handle the ray tracing and graphics for objects not placed at z=0 (and their corresponding conjugate planes)
- added parameters to ObjectRays: 'z', 'rayColors', 'color'
- when 'color' is given to an ObjectRays, the Images will be of the same color, but not filled, to help distinguish multiple objects

### Example

```
path = ImagingPath()
path.append(Space(d=10))
path.append(Lens(f=10, diameter=100, label="Collector"))
path.append(Space(d=10+30))
path.append(Lens(f=30, diameter=100, label="Condenser"))
path.append(Space(d=30+30))
path.append(Lens(f=30, diameter=100, label="Objective"))
path.append(Space(d=30+30))
path.append(Lens(f=30, diameter=100, label="Tube"))
path.append(Space(d=30+30))
path.append(Lens(f=30, diameter=100, label="Eyepiece"))
path.append(Space(d=30+2))
path.append(Lens(f=2, diameter=10, label="Eye Entrance"))
path.append(Space(d=2))

path.design(lampRayColors='y')
path.display(raysList=[LampRays(15, N=50),
                       ObjectRays(40, halfAngle=0, T=1, z=20, rayColors='r', color='r'),
                       ObjectRays(30, halfAngle=0, T=1, z=80, rayColors='g', color='g')], removeBlocked=False)

```
![image](https://user-images.githubusercontent.com/29587649/88346692-f022ab80-cd16-11ea-8e37-3d2d0e1c8f16.png)

Or a simpler path with an Object at z=2, overlayed with FOV principal and axial rays
```
path = ImagingPath()
path.append(Space(d=10))
path.append(Lens(f=5, diameter=3))
path.append(Space(d=3))
path.append(Aperture(diameter=3))
path.append(Space(d=17))
path.display(ObjectRays(5, 0.1, z=2),
             removeBlocked=False)
```
![image](https://user-images.githubusercontent.com/29587649/88346929-8f47a300-cd17-11ea-8dce-e305547eb7f3.png)
