### PR TITLE
Improve LampRays and ObjectRays 

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -116,9 +116,6 @@ class Figure:
                 warnings.warn("Infinite image size: cannot use limitObjectToFieldOfView=True.")
                 self.designParams['limitObjectToFieldOfView'] = False
 
-        if not self.designParams['limitObjectToFieldOfView']:
-            note1 = "Object height: {0:.2f}".format(self.path.objectHeight)
-
         if self.designParams['onlyPrincipalAndAxialRays']:
             (stopPosition, stopDiameter) = self.path.apertureStop()
             if stopPosition is None or self.path.principalRay() is None:

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -777,6 +777,7 @@ class RandomLambertianRays(RandomRays):
         self.append(ray)
         return ray
 
+
 class ObjectRays(UniformRays):
     def __init__(self, diameter, halfAngle=1.0, H=3, T=3, z=0, rayColors=None, color=None):
         super(ObjectRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=halfAngle, thetaMin=-halfAngle, M=H, N=T)
@@ -784,8 +785,19 @@ class ObjectRays(UniformRays):
         self.rayColors = rayColors
         self.color = color
 
-class LampRays(RandomUniformRays):
-    def __init__(self, diameter, NA=1.0, N=10000):
-        super(LampRays, self).__init__(yMax=diameter/2, yMin=-diameter/2, thetaMax=NA, thetaMin=-NA, maxCount=N)
 
+class LampRays(RandomUniformRays, Rays):
+    def __init__(self, diameter, NA=1.0, N=10000, random=False):
+        if random:
+            RandomUniformRays.__init__(self, yMax=diameter/2, yMin=-diameter/2, thetaMax=NA, thetaMin=-NA, maxCount=N)
+        else:
+            self.yMin = -diameter/2
+            self.yMax = diameter/2
+            self.maxCount = N
 
+            rays = []
+            heights = np.linspace(self.yMin, self.yMax, N, endpoint=True)
+            angles = np.linspace(-NA, NA, N, endpoint=True)
+            for y, theta in zip(heights, angles):
+                rays.append(Ray(y, theta))
+            Rays.__init__(self, rays=rays)

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -525,10 +525,17 @@ class UniformRays(Rays):
         self.M = M
         self.N = N
         rays = []
-        for y in np.linspace(self.yMin, self.yMax, self.M, endpoint=True):
+
+        if self.M == 1:
+            heights = [0]
+        else:
+            heights = np.linspace(self.yMin, self.yMax, self.M, endpoint=True)
+
+        for y in heights:
             for theta in np.linspace(self.thetaMin, self.thetaMax, self.N, endpoint=True):
                 rays.append(Ray(y, theta))
         super(UniformRays, self).__init__(rays=rays)
+
 
 class LambertianRays(Rays):
     """A list of rays with Lambertian distribution.


### PR DESCRIPTION
## Changes
- LampRays is now by default a linear distribution of rays (accross 'y' and 'theta' to fill diameter and NA). 
- Added `random` arg in LampRays to get a random distribution (as before). 
- Added an edge case for H=1 when creating UniformRays (ObjectRays) so that the fan is created at y=0 and not y=-yMin
- Remove figure text note about Object Height since we are now always talking about FOV. Keep FOV and Image size text note.

## Examples 

### LampRays
with default argument `random=True`. We can also see that it now writes FOV size instead of object height
![image](https://user-images.githubusercontent.com/29587649/88722385-26847000-d0f5-11ea-8c58-65b08d32e1cb.png)

```
path = ImagingPath()
path.append(Space(d=10))
path.append(Lens(f=10, diameter=100, label="Collector"))
path.append(Space(d=10+30))
path.append(Lens(f=30, diameter=100, label="Condenser"))
path.append(Space(d=30+30))
path.append(Lens(f=30, diameter=100, label="Objective"))
path.append(Space(d=30+30))
path.append(Lens(f=30, diameter=100, label="Tube"))
path.append(Space(d=30+30))
path.append(Lens(f=30, diameter=100, label="Eyepiece"))
path.append(Space(d=30+2))
path.append(Lens(f=2, diameter=10, label="Eye Entrance"))
path.append(Space(d=2))

path.design(lampRayColors='y')
path.display(raysList=[LampRays(15, N=50, random=False),
                       ObjectRays(40, halfAngle=0, T=1, z=20, rayColors='r', color='r'),
                       ObjectRays(30, halfAngle=0, T=1, z=80, rayColors='g', color='g')], removeBlocked=False)
```

### ObjectRays(H=1)
![image](https://user-images.githubusercontent.com/29587649/88722443-3dc35d80-d0f5-11ea-830b-c6fcb5e65081.png)

```
path = ImagingPath()
path.design(lampRayColors='r')
path.append(Space(d=10))
path.append(Lens(f=5, diameter=3))
path.append(Space(d=3))
path.append(Aperture(diameter=3))
path.append(Space(d=17))
path.display(ObjectRays(5, 0.1, H=1),
             removeBlocked=False)
```