### PR TITLE
Update figure note & LampRays

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -123,10 +123,8 @@ class Figure:
                 warnings.warn("No aperture stop in system: cannot use onlyPrincipalAndAxialRays=True since they are "
                               "not defined.")
                 self.designParams['onlyPrincipalAndAxialRays'] = False
-            else:
-                note2 = "Only chief and marginal rays shown"
 
-        label = Label(x=0.05, y=0.02, text=note1 + "\n" + note2, fontsize=12*self.fontScale,
+        label = Label(x=0.05, y=0, text=note1 + "\n" + note2, fontsize=12*self.fontScale,
                       useDataUnits=False, alignment='left')
         self.labels.append(label)
 

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -100,7 +100,6 @@ class Figure:
         """ Configure the imaging path and the figure according to the display conditions. """
 
         note1 = ""
-        note2 = ""
         if self.designParams['limitObjectToFieldOfView']:
             fieldOfView = self.path.fieldOfView()
             if fieldOfView != float('+Inf'):
@@ -124,7 +123,7 @@ class Figure:
                               "not defined.")
                 self.designParams['onlyPrincipalAndAxialRays'] = False
 
-        label = Label(x=0.05, y=0, text=note1 + "\n" + note2, fontsize=12*self.fontScale,
+        label = Label(x=0.05, y=0, text=note1, fontsize=12*self.fontScale,
                       useDataUnits=False, alignment='left')
         self.labels.append(label)
 

--- a/raytracing/rays.py
+++ b/raytracing/rays.py
@@ -788,19 +788,20 @@ class ObjectRays(UniformRays):
 
 
 class LampRays(RandomUniformRays, Rays):
-    def __init__(self, diameter, NA=1.0, N=10000, random=False, z=0, rayColors=None):
+    def __init__(self, diameter, NA=1.0, N=100, random=False, z=0, rayColors=None, T=10):
         if random:
             RandomUniformRays.__init__(self, yMax=diameter/2, yMin=-diameter/2, thetaMax=NA, thetaMin=-NA, maxCount=N)
         else:
             self.yMin = -diameter/2
             self.yMax = diameter/2
-            self.maxCount = N
+            self.maxCount = N*T
 
             rays = []
             heights = np.linspace(self.yMin, self.yMax, N, endpoint=True)
-            angles = np.linspace(-NA, NA, N, endpoint=True)
-            for y, theta in zip(heights, angles):
-                rays.append(Ray(y, theta))
+            angles = np.linspace(-NA, NA, T, endpoint=True)
+            for y in heights:
+                for theta in angles:
+                    rays.append(Ray(y, theta))
             Rays.__init__(self, rays=rays)
 
         self.z = z


### PR DESCRIPTION
- Remove old figure note saying 'Only Chief and Marginal Rays Shown' since it is never really the case now with interactivity the user sees on the right what is displayed. 
- When random=False (default) the LampRays now defines N point sources accross the diameter for which T rays are traced from -NA to +NA. This is a correct approximation of the rays. 

Example with diameter=5, NA=0.5, N=10, T=20
![image](https://user-images.githubusercontent.com/29587649/89562709-64198500-d7e8-11ea-97d7-a2a6be01e1ed.png)
