### PR TITLE
Fix #360 documentation build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.6.10
+   version: 3.7
    install:
       - requirements: docs/requirements.txt
       - method: setuptools

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.6
+   version: 3.6.10
    install:
       - requirements: docs/requirements.txt
       - method: setuptools

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setuptools.setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     monte carlo design raytracing',
     packages=setuptools.find_packages(),
     install_requires=['matplotlib>=3', 'numpy'],
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     package_data = {
         # If any package contains *.txt or *.rst files, include them:
         '': ['*.png'],


### PR DESCRIPTION
Weird issue where pip recommends Numpy 1.20 for python 3.6.12, but 1.20 requires 3.7 so the build fails to install Numpy. I tried to specify the use of Python 3.6.10 for the build but it only accepts 0.1 increments, so I set the documentation build version at 3.7. Note that Raytracing still works on python 3.6. 
Fix issue #360 

I tested the build on ReadTheDocs with [this branch](https://raytracing.readthedocs.io/en/fix-docs-build/) and it works. 