### PR TITLE
Fix flipped graphics of surface-based elements and objectives

### DIFF
--- a/raytracing/axicon.py
+++ b/raytracing/axicon.py
@@ -132,7 +132,7 @@ class Axicon(Matrix):
         raise TypeError("Cannot use Axicon with GaussianBeam, only with Ray")
 
     @property
-    def surfaces(self):
+    def forwardSurfaces(self):
         """ A list of surfaces that represents the element for drawing purposes
         """
         minThickness = - np.tan(self.alpha) * self.displayHalfHeight()

--- a/raytracing/graphics.py
+++ b/raytracing/graphics.py
@@ -423,10 +423,7 @@ class ObjectiveGraphic(MatrixGroupGraphic):
                   (0, halfHeight)]
 
         if self.matrixGroup.isFlipped:
-            print("Flipped matrix graphic not implemented.")
-        #     trans = transforms.Affine2D().scale(-1).translate(tx=z + L, ty=0) + axes.transData
-        # else:
-        #     trans = transforms.Affine2D().translate(tx=z, ty=0) + axes.transData
+            points = [(-a + L, b) for a, b in points]
 
         components = [Polygon(points, lineStyle='--')]
 

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -162,7 +162,7 @@ class Matrix(object):
         return self.A * self.D - self.B * self.C
 
     @property
-    def surfaces(self):
+    def forwardSurfaces(self):
         """ A list of surfaces that represents the element for drawing purposes """
         return []
     
@@ -1421,7 +1421,7 @@ class Lens(Matrix):
         self._physicalHalfHeight = 4  # FIXME: keep a minimum half height when infinite ?
 
     @property
-    def surfaces(self):
+    def forwardSurfaces(self):
         """ A list of surfaces that represents the element for drawing purposes 
 
         For a thin lens, obviously the user does not worry about the details
@@ -1525,7 +1525,7 @@ in version 1.2.8 to maintain the sign convention", UserWarning)
                                            label=label)
 
     @property
-    def surfaces(self):
+    def forwardSurfaces(self):
         """ A list of surfaces that represents the element for drawing purposes 
         """
         return [SphericalInterface(R=2/self.C)]
@@ -1667,7 +1667,7 @@ class DielectricInterface(Matrix):
                                                   label=label)
 
     @property
-    def surfaces(self):
+    def forwardSurfaces(self):
         """ A list of surfaces that represents the element for drawing purposes 
         """
         return [SphericalInterface(R=self.R, n=self.n2)]
@@ -1748,7 +1748,7 @@ class ThickLens(Matrix):
                                         label=label)
 
     @property
-    def surfaces(self):
+    def forwardSurfaces(self):
         """ A list of surfaces that represents the element for drawing purposes 
         """
         return [SphericalInterface(R=self.R1, n=self.n, L=self.L),
@@ -1859,7 +1859,7 @@ class DielectricSlab(ThickLens):
                                              label=label)
 
     @property
-    def surfaces(self) -> List[Interface]:
+    def forwardSurfaces(self) -> List[Interface]:
         """ A list of surfaces that represents the element for drawing purposes. """
         return [FlatInterface(L=self.L, n=self.n), FlatInterface()]
 

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -165,6 +165,24 @@ class Matrix(object):
     def forwardSurfaces(self):
         """ A list of surfaces that represents the element for drawing purposes """
         return []
+
+    @property
+    def surfaces(self):
+        surfaces = self.forwardSurfaces
+
+        if self.isFlipped:
+            surfaces.reverse()
+            for i, surface in enumerate(surfaces):
+                if type(surface) == SphericalInterface:
+                    surface.R *= -1
+                if (i + 1) == len(surfaces):
+                    nextSurface = Interface()
+                else:
+                    nextSurface = surfaces[i + 1]
+                surface.n = nextSurface.n
+                surface.L = nextSurface.L
+
+        return surfaces
     
     def __mul__(self, rightSide):
         """Operator overloading allowing easy-to-read matrix multiplication

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -468,6 +468,7 @@ class MatrixGroup(Matrix):
     def flipOrientation(self):
         """ Flip the orientation (forward-backward) of this group of elements.
         Each element is also flipped individually. """
+        self.isFlipped = not self.isFlipped
 
         allElements = self.elements
         allElements.reverse()

--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -149,7 +149,7 @@ class AchromatDoubletLens(MatrixGroup):
         return [{'z': f1, 'label': '$F_f$'}, {'z': f2, 'label': '$F_b$'}]
 
     @property
-    def surfaces(self) -> List[Interface]:
+    def forwardSurfaces(self) -> List[Interface]:
         return [SphericalInterface(R=self.R1, L=self.tc1, n=self.n1),
                 SphericalInterface(R=self.R2, L=self.tc2, n=self.n2),
                 SphericalInterface(R=self.R3)]
@@ -268,7 +268,7 @@ class SingletLens(MatrixGroup):
         return [{'z': f1, 'label': '$F_f$'}, {'z': f2, 'label': '$F_b$'}]
 
     @property
-    def surfaces(self) -> List[Interface]:
+    def forwardSurfaces(self) -> List[Interface]:
         return [SphericalInterface(R=self.R1, L=self.tc, n=self.n),
                 SphericalInterface(R=self.R2)]
 

--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -347,7 +347,6 @@ reproduce the objective."
 
     def flipOrientation(self):
         super(Objective, self).flipOrientation()
-        self.isFlipped = not self.isFlipped
 
         z = 0
         for element in self.elements:


### PR DESCRIPTION
*Requires review

### Fix for flipped graphics
**Surfaces**
"renamed" all `surfaces` property occurences for `forwardSurfaces`. Redefined `surfaces` property in Matrix baseclass which returns `forwardSurfaces` unless matrix or matrixgroup `isFlipped` where it reinitiates the surfaces in a flipped order (correcting the medium index & length). 

**Objectives** (#364 and part of #363)
Simply flipping the default polygon graphic.

### Examples
**Example display for a surface-based element (AchromatDoubletLens) and an objective. On the left is the 'forward' setup, and on the right is the flipped version. While the graphics look fine I am not sure of the properties.**

![flip](https://user-images.githubusercontent.com/29587649/105521380-cdfbed00-5ca9-11eb-861e-5ea7eb8d77c5.png)
 