### PR TITLE
Optional arguments for Objective class

### DIFF
--- a/raytracing/nikon.py
+++ b/raytracing/nikon.py
@@ -18,9 +18,9 @@ class LWD16X(Objective):
 
     def __init__(self):
         super(LWD16X, self).__init__(f=200/16,
-                                         NA=1.95*0.8,
-                                         focusToFocusLength=75,
-                                         backAperture=20,
-                                         workingDistance=3,
-                                         label='CFI75 LWD 16x W',
-                                         url="https://www.thorlabs.com/thorproduct.cfm?partnumber=N16XLWD-PF")
+                                     NA=1.95*0.8,
+                                     focusToFocusLength=75,
+                                     backAperture=20,
+                                     workingDistance=3,
+                                     label='CFI75 LWD 16x W',
+                                     url="https://www.thorlabs.com/thorproduct.cfm?partnumber=N16XLWD-PF")

--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -312,28 +312,30 @@ class Objective(MatrixGroup):
 
         self.f = f
         self.NA = NA
-        self.magnification = magnification
-        self.fieldNumber = fieldNumber
         self.focusToFocusLength = focusToFocusLength
         self.backAperture = backAperture
         self.workingDistance = workingDistance
-        self.frontAperture = 2 * (NA * workingDistance)
+
+        self.magnification = magnification
+        self.fieldNumber = fieldNumber
+
+        self.frontAperture = 2 * (self.NA * self.workingDistance)
         self.isFlipped = False
         self.url = url
 
-        elements = [Aperture(diameter=backAperture, label="backAperture"),
-                    Space(d=f),
-                    Matrix(1, 0, 0, 1, physicalLength=focusToFocusLength - 2 * f),
-                    Lens(f=f),
-                    Space(d=f - workingDistance),
+        elements = [Aperture(diameter=self.backAperture, label="backAperture"),
+                    Space(d=self.f),
+                    Matrix(1, 0, 0, 1, physicalLength=self.focusToFocusLength - 2 * self.f),
+                    Lens(f=self.f),
+                    Space(d=self.f - self.workingDistance),
                     Aperture(diameter=self.frontAperture, label="frontAperture"),
-                    Space(d=workingDistance)]
+                    Space(d=self.workingDistance)]
 
         super(Objective, self).__init__(elements=elements, label=label)
 
         self.frontVertex = 0
-        self.backVertex = focusToFocusLength - workingDistance
-        self.apertureDiameter = backAperture
+        self.backVertex = self.focusToFocusLength - self.workingDistance
+        self.apertureDiameter = self.backAperture
 
         if not Objective.warningDisplayed:
             msg = "Objective class not fully tested. \

--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -296,7 +296,7 @@ class Objective(MatrixGroup):
     """
     warningDisplayed = False
 
-    def __init__(self, f, NA, focusToFocusLength, backAperture, workingDistance, magnification, fieldNumber, url=None, label=''):
+    def __init__(self, f, NA, focusToFocusLength, backAperture, workingDistance, magnification=None, fieldNumber=None, url=None, label=''):
         """ General microscope objective, approximately correct.
 
         We model the objective as an ideal lens with back focal point at the entrance
@@ -343,7 +343,11 @@ reproduce the objective."
             Objective.warningDisplayed = True
 
     def maximumOpticalInvariant(self):
-        return (self.fieldNumber/2)/self.magnification * self.NA
+        if self.magnification is None or self.fieldNumber is None:
+            raise AttributeError("Cannot compute the maximum optical invariant without fieldNumber "
+                                 "and magnification defined.")
+        else:
+            return (self.fieldNumber/2)/self.magnification * self.NA
 
     def flipOrientation(self):
         super(Objective, self).flipOrientation()


### PR DESCRIPTION
When defining an objective, `magnification` and `fieldNumber` are not required. With this pull-request they are now officially optional arguments. This doesn't change the API. 

Their only usage is to retrieve `maximumOpticalInvariant`. Calling this method now returns an AttributeError if the above-mentioned arguments were not defined. This method is not used anywhere in the code or in the examples, so I assume it is not essential even though I'm not a user (please review this). 

I also wonder if there is another way to compute the `maximumOpticalInvariant = 0.5FN /magnification * NA` without one or both of the optional attributes...

I think this solves the arguments issue in #363 if the `maximumOpticalInvariant` method is indeed not required.