### PR TITLE
Named tuples for magnification, focal lengths and principal planes.

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -439,7 +439,7 @@ class ImagingPath(MatrixGroup):
         ratio is maximum is the aperture stop.
         """
         if not self.hasFiniteApertureDiameter():
-            return (None, float('+Inf'))
+            return Stop(z=None, diameter=float('+Inf'))
         else:
             ray = Ray(y=0, theta=0.1)  # Any ray angle will do
             rayTrace = self.trace(ray)
@@ -455,7 +455,7 @@ class ImagingPath(MatrixGroup):
                     apertureStopDiameter = ray.apertureDiameter
                     maxRatio = ratio
 
-            return (apertureStopPosition, apertureStopDiameter)
+            return Stop(z=apertureStopPosition, diameter=apertureStopDiameter)
 
     def entrancePupil(self):
         """The entrance pupil is the image of the aperture stop
@@ -591,7 +591,7 @@ class ImagingPath(MatrixGroup):
                 y += dy
                 wasBlocked = outputChiefRay.isBlocked
                 if abs(y) > self.maxHeight and not wasBlocked:
-                    return Stop(fieldStopPosition, fieldStopDiameter)
+                    return Stop(z=fieldStopPosition, diameter=fieldStopDiameter)
 
             for ray in chiefRayTrace:
                 if ray.isBlocked:
@@ -599,7 +599,7 @@ class ImagingPath(MatrixGroup):
                     fieldStopDiameter = ray.apertureDiameter
                     break
 
-        return Stop(fieldStopPosition, fieldStopDiameter)
+        return Stop(z=fieldStopPosition, diameter=fieldStopDiameter)
 
     def fieldOfView(self):
         """The field of view is the length visible before the chief

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -7,7 +7,7 @@ import numpy as np
 """ We start with general, useful namedtuples to simplify management of values """
 from typing import NamedTuple
 
-class PrincipalRays(NamedTuple):
+class MarginalRays(NamedTuple):
     up: Ray = None
     down: Ray = None
 
@@ -283,14 +283,14 @@ class ImagingPath(MatrixGroup):
         """
         (stopPosition, stopDiameter) = self.apertureStop()
         if stopPosition is None:
-            return PrincipalRays(None, None)  # No aperture stop -> no marginal rays
+            return MarginalRays(None, None)  # No aperture stop -> no marginal rays
 
         transferMatrixToApertureStop = self.transferMatrix(upTo=stopPosition)
         A = transferMatrixToApertureStop.A
         B = transferMatrixToApertureStop.B
 
         if transferMatrixToApertureStop.isImaging:
-            return PrincipalRays(None, None)
+            return MarginalRays(None, None)
 
         thetaUp = (stopDiameter / 2.0 - A * y) / B
         thetaDown = (-stopDiameter / 2.0 - A * y) / B
@@ -298,7 +298,7 @@ class ImagingPath(MatrixGroup):
         if thetaDown > thetaUp:
             (thetaUp, thetaDown) = (thetaDown, thetaUp)
 
-        return PrincipalRays(Ray(y=y, theta=thetaUp), Ray(y=y, theta=thetaDown))
+        return MarginalRays(up=Ray(y=y, theta=thetaUp), down=Ray(y=y, theta=thetaDown))
 
     def axialRay(self):
         """This function returns the axial ray of the system, also known as

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -15,6 +15,7 @@ class Stop(NamedTuple):
     z: float = 0
     diameter: float = None
 
+
 class ImagingPath(MatrixGroup):
     """ImagingPath: the main class of the module, allowing
     the combination of Matrix() or MatrixGroup() to be used 

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -12,6 +12,10 @@ import warnings
 """ We start with general, useful namedtuples to simplify management of values """
 from typing import NamedTuple
 
+class CardinalPoint(NamedTuple):
+    z1: float = None
+    z2: float = None
+
 class FocalLengths(NamedTuple):
     f1: float = None
     f2: float = None
@@ -23,6 +27,10 @@ class PrincipalPlanes(NamedTuple):
 class Magnification(NamedTuple):
     transverse: float = None
     angular: float = None
+
+class Conjugate(NamedTuple):
+    d: float = None
+    transferMatrix:'Matrix' = None
 
 
 def warningLineFormat(message, category, filename, lineno, line=None):
@@ -1154,9 +1162,9 @@ class Matrix(object):
         if self.hasPower:
             (f1, f2) = self.focalDistances()
             (p1, p2) = self.principalPlanePositions(z)
-            return (p1 - f1, p2 + f2)
+            return CardinalPoint(p1 - f1, p2 + f2)
         else:
-            return (None, None)
+            return CardinalPoint(None, None)
 
     def principalPlanePositions(self, z):
         """ Positions of the input and output principal planes.
@@ -1240,7 +1248,7 @@ class Matrix(object):
             distance = -self.B / self.D
             conjugateMatrix = Space(d=distance, n=self.backIndex) * self
 
-        return (distance, conjugateMatrix)
+        return Conjugate(d=distance, transferMatrix=conjugateMatrix)
 
     def backwardConjugate(self):
         r""" With an image at the back edge of the element,
@@ -1289,7 +1297,7 @@ class Matrix(object):
         # This element is A*d + B, A is precisely 0, d is large, therefore B' == 0.
         conjugateMatrix.B = 0 
 
-        return (distance, conjugateMatrix)
+        return Conjugate(d=distance, transferMatrix=conjugateMatrix)
 
     def magnification(self):
         """The magnification of the element
@@ -1551,8 +1559,6 @@ class CurvedMirror(Matrix):
     """
 
     def __init__(self, R, diameter=float('+Inf'), label=''):
-        warnings.warn("The sign of the radius of curvature in CurvedMirror was changed \
-in version 1.2.8 to maintain the sign convention", UserWarning)
         super(CurvedMirror, self).__init__(A=1, B=0, C=2 / float(R), D=1,
                                            physicalLength=0,
                                            apertureDiameter=diameter,

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -9,6 +9,21 @@ import sys
 import math
 import warnings
 
+""" We start with general, useful namedtuples to simplify management of values """
+from typing import NamedTuple
+
+class FocalLengths(NamedTuple):
+    f1: float = None
+    f2: float = None
+
+class PrincipalPlanes(NamedTuple):
+    z1: float = None
+    z2: float = None
+
+class Magnification(NamedTuple):
+    transverse: float = None
+    angular: float = None
+
 
 def warningLineFormat(message, category, filename, lineno, line=None):
     return '\n%s:%s\n%s:%s\n' % (filename, lineno, category.__name__, message)
@@ -986,6 +1001,7 @@ class Matrix(object):
         focal distances: (5.0, 5.0)
 
         """
+
         if self.hasPower:
             focalLength2 = -1.0 / self.C  # left (n1) to right (n2)
             focalLength1 = -(self.frontIndex / self.backIndex) / self.C  # right (n2) to left (n2)
@@ -993,7 +1009,7 @@ class Matrix(object):
             focalLength1 = float("+Inf")
             focalLength2 = float("+Inf")
 
-        return (focalLength1, focalLength2)
+        return FocalLengths(f1=focalLength1, f2=focalLength2)
 
     def backFocalLength(self):
         """ The focal lengths measured from the back vertex.
@@ -1176,7 +1192,7 @@ class Matrix(object):
             p1 = None
             p2 = None
 
-        return (p1, p2)
+        return PrincipalPlanes(z1=p1, z2=p2)
 
     def forwardConjugate(self):
         r""" With an object at the front edge of the element, where
@@ -1280,9 +1296,11 @@ class Matrix(object):
 
         Returns
         -------
-        magnification : array
+        magnification : namedtuple (transverse, angular)
+            You can access via indexes or .transverse and .angular
             index [0] output object is A in the matrix and
             index [1] is D in the matrix.
+
 
         Examples
         --------
@@ -1304,9 +1322,9 @@ class Matrix(object):
         """
 
         if self.isImaging:
-            return (self.A, self.D)
+            return Magnification(self.A, self.D)
         else:
-            return (None, None)
+            return Magnification(None, None)
 
     def flipOrientation(self):
         """We flip the element around (as in, we turn a lens around front-back).

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1162,9 +1162,9 @@ class Matrix(object):
         if self.hasPower:
             (f1, f2) = self.focalDistances()
             (p1, p2) = self.principalPlanePositions(z)
-            return CardinalPoint(p1 - f1, p2 + f2)
+            return CardinalPoint(z1=p1 - f1, z2=p2 + f2)
         else:
-            return CardinalPoint(None, None)
+            return CardinalPoint(z1=None, z2=None)
 
     def principalPlanePositions(self, z):
         """ Positions of the input and output principal planes.

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -60,6 +60,14 @@ class TestImagingPath(envtest.RaytracingTestCase):
         fourF = ImagingPath(elements)
         self.assertTupleEqual(fourF.apertureStop(), (40, 700))
 
+    def testApertureStopNamedTuple(self):
+        f1 = 10
+        f2 = 20
+        elements = [Space(f1), Lens(f1, 1000), Space(f1 + f2), Lens(f2, 700), Space(f2)]
+        fourF = ImagingPath(elements)
+        self.assertEqual(fourF.apertureStop().diameter, 700)
+        self.assertEqual(fourF.apertureStop().z, 40)
+
     def testEntrancePupilInfiniteApertureDiam(self):
         space = Space(2)
         tLens = ThickLens(1, 10, -9, 2)
@@ -120,6 +128,15 @@ class TestImagingPath(envtest.RaytracingTestCase):
         lens2 = Lens(10, 50)
         path = ImagingPath([space, lens, space2, lens2, space])
         self.assertTupleEqual(path.fieldStop(), (30, 50))
+
+    def testFieldStopNamedTuple(self):
+        space = Space(10)
+        lens = Lens(10, 25)
+        space2 = Space(20)
+        lens2 = Lens(10, 50)
+        path = ImagingPath([space, lens, space2, lens2, space])
+        self.assertEqual(path.fieldStop().z, 30)
+        self.assertEqual(path.fieldStop().diameter, 50)
 
     def testEntrancePupilNoBackwardConjugate(self):
         path = ImagingPath()
@@ -230,6 +247,12 @@ class TestImagingPath(envtest.RaytracingTestCase):
         self.assertEqual(ray2.y, 10)
         self.assertEqual(ray2.theta, -1.5)
 
+    def testMarginalRays(self):
+        path = ImagingPath(System2f(10, 10))
+        rays = path.marginalRays(10)
+        self.assertEqual(rays.up, rays[0])
+        self.assertEqual(rays.down, rays[1])
+
     def testMarginalRaysThetaUpAndDownFlipped(self):
         path = ImagingPath(System2f(5))
         tl = ThickLens(1.1, 0.1, -0.1, 10)
@@ -309,7 +332,6 @@ class TestImagingPath(envtest.RaytracingTestCase):
         path = ImagingPath(System2f(10, 10))
         with self.assertRaises(ValueError):
             path.chiefRay()
-
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -427,6 +427,22 @@ class TestMatrix(envtest.RaytracingTestCase):
         focalLengths = (-1 / 3, -1 / 3)
         self.assertTupleEqual(m.effectiveFocalLengths(), focalLengths)
 
+    def testEffectiveFocalIsNamedTuple(self):
+        m = Matrix(A=1, B=0, C=3, D=1)
+        focalLengths = (-1 / 3, -1 / 3)
+
+        actualFocalLengths = m.effectiveFocalLengths() 
+        self.assertEqual(actualFocalLengths.f1, focalLengths[0])
+        self.assertEqual(actualFocalLengths.f2, focalLengths[0])
+
+    def testEffectiveFocalIsNamedTuple(self):
+        m = Matrix(A=1, B=0, C=3, D=1)
+
+        focalLengths = FocalLengths(f1=-1 / 3, f2=-1 / 3)
+        self.assertEqual(focalLengths.f1, -1/3)
+        self.assertEqual(focalLengths.f2, -1/3)
+
+
     def testEffectiveFocalLengthsNoPower(self):
         m = Matrix(1, 0, 0, 1)
         focalLengths = (inf, inf)
@@ -533,6 +549,12 @@ class TestMatrix(envtest.RaytracingTestCase):
     def testMagnificationImaging(self):
         m = Matrix()
         self.assertTupleEqual(m.magnification(), (1, 1))
+
+    def testMagnificationNamedTupleImaging(self):
+        m = Matrix()
+        mag = m.magnification()
+        self.assertAlmostEqual(mag.transverse, 1)
+        self.assertAlmostEqual(mag.angular, 1)
 
     def testMagnificationNotImaging(self):
         m = Matrix(B=1)

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -476,6 +476,13 @@ class TestMatrix(envtest.RaytracingTestCase):
         p2 = 1
         self.assertTupleEqual(m.principalPlanePositions(0), (p1, p2))
 
+    def testPrincipalPlanePositionsIsNamedTuple(self):
+        m = Matrix(A=1, B=0, C=1, D=1, physicalLength=1)
+        p1 = 0
+        p2 = 1
+        self.assertEqual(m.principalPlanePositions(0).z1, p1)
+        self.assertEqual(m.principalPlanePositions(0).z2, p2)
+
     def testPrincipalPlanePositionsNoPower(self):
         m = Matrix()
         self.assertTupleEqual(m.principalPlanePositions(0), (None, None))
@@ -487,6 +494,15 @@ class TestMatrix(envtest.RaytracingTestCase):
         f2 = -0.1
         p2 = 16 / 15
         self.assertTupleEqual(m.focusPositions(0), (p1 - f1, p2 + f2))
+
+    def testFocusPositionsIsNamedTuple(self):
+        m = Matrix(A=1 / 3, B=0, C=10, D=3, physicalLength=1)
+        f1 = -0.1
+        p1 = 0.2
+        f2 = -0.1
+        p2 = 16 / 15
+        self.assertEqual(m.focusPositions(0).z1, p1 - f1)
+        self.assertEqual(m.focusPositions(0).z2, p2 + f2)
 
     def testFocusPositionsNoPower(self):
         m = Matrix()
@@ -510,6 +526,12 @@ class TestMatrix(envtest.RaytracingTestCase):
         self.assertEqual(m1.determinant, 1)
         self.assertEqual(m2.determinant, 1)
 
+    def testForwardConjugateIsNamedTuple(self):
+        m1 = Lens(f=5) * Space(d=10)
+        conjugate = m1.forwardConjugate()
+        self.assertEqual(conjugate.d, 10)
+        self.assertIsNotNone(conjugate.transferMatrix)
+
     def testFiniteForwardConjugates_2(self):
         m1 = Matrix(1, 5, 0, 1) * Matrix(1, 0, -1 / 5, 1) * Matrix(1, 10, 0, 1)
         (d, m2) = m1.forwardConjugate()
@@ -529,6 +551,13 @@ class TestMatrix(envtest.RaytracingTestCase):
         d, mat = m.backwardConjugate()
         self.assertEqual(d, inf)
         self.assertIsNotNone(mat)
+
+
+    def testBackConjugateIsNamedTuple(self):
+        m = Matrix(A=0, B=1, C=-1, D=0)
+        conjugate = m.backwardConjugate()
+        self.assertEqual(conjugate.d, inf)
+        self.assertIsNotNone(conjugate.transferMatrix)
 
     def testFiniteBackConjugate_1(self):
         m1 = Matrix(1, 10, 0, 1) * Matrix(1, 0, -1 / 5, 1)


### PR DESCRIPTION
`Magnification`, `FocalLengths`, `PrincipalPlanes`, `Stop`, `MarginalRays` and others were defined as namedtuples to make manipulation and meaning easier for users.

I wonder if there are better "NamedTuples" that could be more general, but so far this is the best I found.