### PR TITLE
Add deprecation warnings for all object references in ImagingPath except objectHeight.

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -77,6 +77,10 @@ class ImagingPath(MatrixGroup):
     def __init__(self, elements: list = None, label=""):
 
         self._objectHeight = 10.0  # object height (full).
+        self.objectPosition = 0.0  # always at z=0 for now.
+        self.fanAngle = 0.1  # full fan angle for rays
+        self.fanNumber = 9  # number of rays in fan
+        self.rayNumber = 3  # number of points on object
 
         # Constants when calculating field stop
         self.precision = 0.000001
@@ -907,7 +911,8 @@ class ImagingPath(MatrixGroup):
                                   'Using default ObjectRays.')
 
         if 'ObjectRays' not in [type(rays).__name__ for rays in raysList]:
-            defaultObject = ObjectRays(diameter=2*self.objectHeight)
+            defaultObject = ObjectRays(self.objectHeight, z=self.objectPosition,
+                                       halfAngle=self.fanAngle, T=self.rayNumber)
             raysList.append(defaultObject)
         else:
             self.figure.designParams['showObjectImage'] = True

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -77,10 +77,6 @@ class ImagingPath(MatrixGroup):
     def __init__(self, elements: list = None, label=""):
 
         self._objectHeight = 10.0  # object height (full).
-        self.objectPosition = 0.0  # always at z=0 for now.
-        self.fanAngle = 0.1  # full fan angle for rays
-        self.fanNumber = 9  # number of rays in fan
-        self.rayNumber = 3  # number of points on object
 
         # Constants when calculating field stop
         self.precision = 0.000001
@@ -911,8 +907,7 @@ class ImagingPath(MatrixGroup):
                                   'Using default ObjectRays.')
 
         if 'ObjectRays' not in [type(rays).__name__ for rays in raysList]:
-            defaultObject = ObjectRays(self.objectHeight, z=self.objectPosition,
-                                       halfAngle=self.fanAngle, T=self.rayNumber)
+            defaultObject = ObjectRays(diameter=2*self.objectHeight)
             raysList.append(defaultObject)
         else:
             self.figure.designParams['showObjectImage'] = True

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -78,9 +78,9 @@ class ImagingPath(MatrixGroup):
 
         self._objectHeight = 10.0  # object height (full).
         self.objectPosition = 0.0  # always at z=0 for now.
-        self.fanAngle = 0.1  # full fan angle for rays
-        self.fanNumber = 9  # number of rays in fan
-        self.rayNumber = 3  # number of points on object
+        self._fanAngle = 0.1  # full fan angle for rays
+        self._fanNumber = 9  # number of rays in fan
+        self._rayNumber = 3  # number of points on object
 
         # Constants when calculating field stop
         self.precision = 0.000001
@@ -112,6 +112,33 @@ class ImagingPath(MatrixGroup):
             raise ValueError("The object height can't be negative.")
         self._objectHeight = objectHeight
         self.figure.designParams['limitObjectToFieldOfView'] = False
+
+    @property
+    def fanAngle(self):
+        return self._fanAngle
+
+    @fanAngle.setter
+    def fanAngle(self, value):
+        warnDeprecatedObjectReferences()
+        self._fanAngle = value
+
+    @property
+    def fanNumber(self):
+        return self._fanNumber
+
+    @fanNumber.setter
+    def fanNumber(self, value):
+        warnDeprecatedObjectReferences()
+        self._fanNumber = value
+
+    @property
+    def rayNumber(self):
+        return self._rayNumber
+
+    @rayNumber.setter
+    def rayNumber(self, value):
+        warnDeprecatedObjectReferences()
+        self._rayNumber = value
 
     def chiefRay(self, y=None):
         r"""This function returns the chief ray for a height y at object.

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -3,12 +3,18 @@ from raytracing import *
 
 inf = float("+inf")
 
+
+
 class TestImagingPath(envtest.RaytracingTestCase):
     def testImagingPath(self):
         path = ImagingPath()
         self.assertIsNotNone(path)
         self.assertListEqual(path.elements, [])
-        self.assertEqual(path.objectHeight, 10)
+        self.assertEqual(path._objectHeight, 10)
+        self.assertEqual(path.objectPosition, 0)
+        self.assertEqual(path.fanAngle, 0.1)
+        self.assertEqual(path.fanNumber, 9)
+        self.assertEqual(path.rayNumber, 3)
         self.assertEqual(path.precision, 1e-6)
         self.assertEqual(path.maxHeight, 10000.0)
         self.assertTrue(path.showImages)

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -3,18 +3,12 @@ from raytracing import *
 
 inf = float("+inf")
 
-
-
 class TestImagingPath(envtest.RaytracingTestCase):
     def testImagingPath(self):
         path = ImagingPath()
         self.assertIsNotNone(path)
         self.assertListEqual(path.elements, [])
-        self.assertEqual(path._objectHeight, 10)
-        self.assertEqual(path.objectPosition, 0)
-        self.assertEqual(path.fanAngle, 0.1)
-        self.assertEqual(path.fanNumber, 9)
-        self.assertEqual(path.rayNumber, 3)
+        self.assertEqual(path.objectHeight, 10)
         self.assertEqual(path.precision, 1e-6)
         self.assertEqual(path.maxHeight, 10000.0)
         self.assertTrue(path.showImages)

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -9,6 +9,8 @@ or radians with angle*degPerRad or angle*radPerDeg """
 degPerRad = 180.0 / math.pi
 radPerDeg = math.pi / 180.0
 
+warnings.simplefilter("default", DeprecationWarning)
+
 
 def isAlmostZero(value, epsilon=1e-3):
     return abs(value) < epsilon

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -59,7 +59,14 @@ def printClassHierarchy(aClass):
     printAllChilds(aClass)
     print("}")
 
+
 def printModuleClasses(moduleName):
     for name, obj in inspect.getmembers(sys.modules[moduleName]):
         if inspect.isclass(obj) and obj.__module__.startswith(moduleName):
             print(obj)
+
+
+def warnDeprecatedObjectReferences():
+    warnings.warn("Object references (fanAngle, fanNumber, rayNumber) will be removed from ImagingPath in future "
+                  "versions. Create an ObjectRays(...) instead and provide it to the display "
+                  "with ImagingPath.display(rays=...)", category=DeprecationWarning)


### PR DESCRIPTION
`fanAngle`, `fanNumber` and `rayNumber` in `ImagingPath` are not necessary: we have `ObjectRays` to create default rays for an object.  The only variable needed is `objectHeight`, which was kept.