### PR TITLE
Improve Figure Warnings

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -118,8 +118,9 @@ class Figure:
             if imageSize != float('+Inf'):
                 note1 += " Image size: {0:.2f}".format(imageSize)
             else:
-                warnings.warn("Infinite image size: cannot use limitObjectToFieldOfView=True.")
-                self.designParams['limitObjectToFieldOfView'] = False
+                if self.designParams['limitObjectToFieldOfView']:
+                    warnings.warn("Infinite image size: cannot use limitObjectToFieldOfView=True.")
+                    self.designParams['limitObjectToFieldOfView'] = False
 
         if self.designParams['onlyPrincipalAndAxialRays']:
             (stopPosition, stopDiameter) = self.path.apertureStop()

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -111,7 +111,9 @@ class Figure:
                 self.path.objectHeight = fieldOfView
                 note1 = "FOV: {0:.2f}".format(self.path.objectHeight)
             else:
-                warnings.warn("Infinite field of view: cannot use limitObjectToFieldOfView=True.")
+                warnings.warn("Infinite field of view: cannot use limitObjectToFieldOfView=True. The object height is "
+                              "instead set to the default value of {}.".format(self.path.objectHeight),
+                              category=Warning)
                 self.designParams['limitObjectToFieldOfView'] = False
 
             imageSize = self.path.imageSize()
@@ -119,14 +121,16 @@ class Figure:
                 note1 += " Image size: {0:.2f}".format(imageSize)
             else:
                 if self.designParams['limitObjectToFieldOfView']:
-                    warnings.warn("Infinite image size: cannot use limitObjectToFieldOfView=True.")
+                    warnings.warn("Infinite image size: cannot use limitObjectToFieldOfView=True. The object height is "
+                                  "instead set to the default value of {}.".format(self.path.objectHeight),
+                                  category=Warning)
                     self.designParams['limitObjectToFieldOfView'] = False
 
         if self.designParams['onlyPrincipalAndAxialRays']:
             (stopPosition, stopDiameter) = self.path.apertureStop()
             if stopPosition is None or self.path.principalRay() is None:
-                warnings.warn("No aperture stop in system: cannot use onlyPrincipalAndAxialRays=True since they are "
-                              "not defined.")
+                warnings.warn("No aperture stop in the system: cannot use onlyPrincipalAndAxialRays=True since they "
+                              "are not defined. Showing the default ObjectRays instead. ", category=Warning)
                 self.designParams['onlyPrincipalAndAxialRays'] = False
 
         label = Label(x=0.05, y=0.02, text=note1, fontsize=12*self.fontScale,


### PR DESCRIPTION
Use Warning instead of UserWarning category, explain what we do, and remove possible duplicate warning. 

Ex:
"Warning:Infinite field of view: cannot use limitObjectToFieldOfView=True. The object height is instead set to the default value of {self.imagingPath.objectHeight}."

"Warning:No aperture stop in the system: cannot use onlyPrincipalAndAxialRays=True since they are not defined. Showing the default ObjectRays instead. "

Fix issue #367 