### PR TITLE
Improve default fanAngle to fit display

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -923,7 +923,7 @@ class ImagingPath(MatrixGroup):
 
         if 'ObjectRays' not in [type(rays).__name__ for rays in raysList]:
             if self.fanAngle is None:
-                self.fanAngle = np.tan(self.figure.displayRange / 2 / self.L)
+                self.fanAngle = np.tan(self.figure.displayRange / 2 / self.L / 5)
             defaultObject = ObjectRays(self.objectHeight, z=self.objectPosition,
                                        halfAngle=self.fanAngle, T=self.rayNumber, H=self.fanNumber)
             raysList.append(defaultObject)
@@ -974,7 +974,7 @@ class ImagingPath(MatrixGroup):
 
         self._objectHeight = diameter
         if fanAngle is None:
-            fanAngle = np.tan(self.figure.displayRange / 2 / self.L)
+            fanAngle = np.tan(self.figure.displayRange / 2 / self.L / 5)
         rays = ObjectRays(diameter, halfAngle=fanAngle, H=fanNumber, T=rayNumber, z=z)
 
         self.display(rays=rays, raysList=None, removeBlocked=removeBlocked, comments=comments,

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -89,7 +89,7 @@ class ImagingPath(MatrixGroup):
 
         self._objectHeight = 10.0  # object height (full).
         self.objectPosition = 0.0  # always at z=0 for now.
-        self.fanAngle = 0.1  # full fan angle for rays
+        self.fanAngle = None  # full fan angle for rays
         self.fanNumber = 3  # number of points on object
         self.rayNumber = 3  # number of rays in fan
 
@@ -922,6 +922,8 @@ class ImagingPath(MatrixGroup):
                                   'Using default ObjectRays.')
 
         if 'ObjectRays' not in [type(rays).__name__ for rays in raysList]:
+            if self.fanAngle is None:
+                self.fanAngle = np.tan(self.figure.displayRange / 2 / self.L)
             defaultObject = ObjectRays(self.objectHeight, z=self.objectPosition,
                                        halfAngle=self.fanAngle, T=self.rayNumber, H=self.fanNumber)
             raysList.append(defaultObject)
@@ -957,7 +959,7 @@ class ImagingPath(MatrixGroup):
                      limitObjectToFieldOfView=limitObjectToFieldOfView,
                      interactive=False, filePath=filePath)
 
-    def displayWithObject(self, diameter, z=0, fanAngle=0.1, fanNumber=3, rayNumber=3, removeBlocked=True, comments=None):
+    def displayWithObject(self, diameter, z=0, fanAngle=None, fanNumber=3, rayNumber=3, removeBlocked=True, comments=None):
         """ Display the optical system and trace the rays.
 
         Parameters
@@ -971,6 +973,8 @@ class ImagingPath(MatrixGroup):
         """
 
         self._objectHeight = diameter
+        if fanAngle is None:
+            fanAngle = np.tan(self.figure.displayRange / 2 / self.L)
         rays = ObjectRays(diameter, halfAngle=fanAngle, H=fanNumber, T=rayNumber, z=z)
 
         self.display(rays=rays, raysList=None, removeBlocked=removeBlocked, comments=comments,


### PR DESCRIPTION
**Small API change: the default `ImagingPath.fanAngle` (soon deprecated) that is used when no `ObjectRays` are provided will change from 0.1 rad to tan(halfDisplayHeight/displayLength /5).

This helps to avoid confusion from the previous default fanAngle that could trace most of the rays outside of the system, which are then blocked and not displayed. 

Fix remaining issue of #374 

**Before/after example**

Before, with `removeBlocked=False`:
![image](https://user-images.githubusercontent.com/29587649/110021793-2f779880-7cf9-11eb-8611-cbe74710a3ef.png)

Now:
![image](https://user-images.githubusercontent.com/29587649/110021608-f6d7bf00-7cf8-11eb-9124-0235c1e594eb.png)
