### PR TITLE
Include inherited methods in documentation

### DIFF
--- a/docs/_templates/autoClass.rst
+++ b/docs/_templates/autoClass.rst
@@ -22,6 +22,18 @@
     {%- endif %}
     {%- endfor %}
 
+.. rubric:: Inherited Methods
+
+.. autosummary::
+    :template: autoFunction.rst
+    :toctree: methods/{{ objname }}
+
+    {% for item in methods %}
+    {%- if item in inherited_members %}
+        ~{{ name }}.{{ item }}
+    {%- endif %}
+    {%- endfor %}
+
 {% endif %}
 {% endblock %}
 

--- a/docs/_templates/autoClass.rst
+++ b/docs/_templates/autoClass.rst
@@ -5,6 +5,7 @@
 .. autoclass:: {{ objname }}
    :no-undoc-members:
    :show-inheritance:
+   :inherited-members:
 
    {% block methods %}
 

--- a/docs/_templates/autoClass.rst
+++ b/docs/_templates/autoClass.rst
@@ -3,7 +3,6 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-   :no-members:
    :no-undoc-members:
    :show-inheritance:
 


### PR DESCRIPTION
Added inherited methods to class summary and new table summary for inherited methods.
Fix #378 

Build :
https://raytracing.readthedocs.io/en/docs-include-inherited-methods/

![image](https://user-images.githubusercontent.com/29587649/110027290-c6dfea00-7cff-11eb-93c0-409c92f001bb.png)
