### PR TITLE
Image size behaviour change

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -484,6 +484,16 @@ class ImagingPath(MatrixGroup):
 
             return Stop(z=apertureStopPosition, diameter=apertureStopDiameter)
 
+    def hasApertureStop(self):
+        """ Returns True if this ImagingPath has an aperture stop.
+        The presence of a single finite diameter element is usually sufficient
+        to have an aperture stop."""
+
+        dist, diam = self.apertureStop()
+        if dist is not None:
+            return True
+        return False
+    
     def entrancePupil(self):
         """The entrance pupil is the image of the aperture stop
         as seen from the object. To obtain this image, we simply
@@ -627,6 +637,20 @@ class ImagingPath(MatrixGroup):
                     break
 
         return Stop(z=fieldStopPosition, diameter=fieldStopDiameter)
+
+    def hasFieldStop(self):
+        """ Returns True if this ImagingPath has a field stop.
+        
+        The presence of a single finite diameter element is not sufficient
+        to have a field stop: we must have at least two finite aperture 
+        elements (maybe more depending on position) to have a field stop.
+        If the system has no field stop, then the fieldOfView will be infinite.
+        """
+
+        dist, diam = self.fieldStop()
+        if dist is not None:
+            return True
+        return False
 
     def fieldOfView(self):
         """The field of view is the length visible before the chief

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -769,7 +769,7 @@ class ImagingPath(MatrixGroup):
             return abs(self.objectHeight * magnification)
 
         fieldOfView = self.fieldOfView()
-        if np.isfinite(fieldOfView):
+        if not np.isfinite(fieldOfView):
             warnings.warn('Field of view is infinite. You can pass useObject=True to use the finite objectHeight.', category=Warning)
 
         return abs(fieldOfView * magnification)

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -728,7 +728,8 @@ class ImagingPath(MatrixGroup):
 
     def imageSize(self):
         """The image size is the object field of view multiplied by magnification.
-        This value is independent from the height of the object.
+        This value is independent from the height of the object. If the FOV
+        is infinite, then the objectHeight is used.
 
         Returns
         -------
@@ -755,7 +756,11 @@ class ImagingPath(MatrixGroup):
             return float("+inf")
 
         magnification = conjugateMatrix.A
-        return abs(fieldOfView * magnification)
+
+        if np.isfinite(fieldOfView):
+            return abs(fieldOfView * magnification)
+        elif self.objectHeight > 0:
+            return abs(self.objectHeight * magnification)
 
     def lagrangeInvariant(self):
         """

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -726,10 +726,19 @@ class ImagingPath(MatrixGroup):
 
         return chiefRay.y
 
-    def imageSize(self):
-        """The image size is the object field of view multiplied by magnification.
-        This value is independent from the height of the object. If the FOV
-        is infinite, then the objectHeight is used.
+    def imageSize(self, useObject=False):
+        """ The actual formal definition of image size is the object field of
+        view multiplied by magnification. This value is independent from the height of
+        the object. However, if the FOV is infinite, this may not be what the user is
+        expecting. In this case a warning is printed and we offer the possibility to
+        use `objectHeight` from the class.
+        
+        Parameters
+        ----------
+
+        useObject : bool default  False
+            Whether or not we use the finite `objectHeight` provided in the class
+            instead of the field of view to calculate the image size.
 
         Returns
         -------
@@ -750,17 +759,20 @@ class ImagingPath(MatrixGroup):
         size of the image : 9.999998574656525
 
         """
-        fieldOfView = self.fieldOfView()
         (distance, conjugateMatrix) = self.forwardConjugate()
         if conjugateMatrix is None:
             return float("+inf")
 
         magnification = conjugateMatrix.A
 
-        if np.isfinite(fieldOfView):
-            return abs(fieldOfView * magnification)
-        elif self.objectHeight > 0:
+        if useObject:
             return abs(self.objectHeight * magnification)
+
+        fieldOfView = self.fieldOfView()
+        if np.isfinite(fieldOfView):
+            warnings.warn('Field of view is infinite. You can pass useObject=True to use the finite objectHeight.', category=Warning)
+
+        return abs(fieldOfView * magnification)
 
     def lagrangeInvariant(self):
         """

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -950,7 +950,7 @@ class ImagingPath(MatrixGroup):
         raise ValueError('The position of the rays does not fit in any spaces.')
 
     def display(self, rays=None, raysList=None, removeBlocked=True, comments=None,
-                onlyPrincipalAndAxialRays=None, limitObjectToFieldOfView=None, interactive=True, filePath=None):
+                onlyPrincipalAndAxialRays=None, limitObjectToFieldOfView=None, interactive=True, filePath=None): #pragma: no cover 
         """ Display the optical system and trace the rays.
 
         Parameters
@@ -1028,7 +1028,7 @@ class ImagingPath(MatrixGroup):
                      limitObjectToFieldOfView=limitObjectToFieldOfView,
                      interactive=False, filePath=filePath)
 
-    def displayWithObject(self, diameter, z=0, fanAngle=None, fanNumber=3, rayNumber=3, removeBlocked=True, comments=None):
+    def displayWithObject(self, diameter, z=0, fanAngle=None, fanNumber=3, rayNumber=3, removeBlocked=True, comments=None): #pragma: no cover 
         """ Display the optical system and trace the rays.
 
         Parameters

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -165,16 +165,22 @@ class TestImagingPath(envtest.RaytracingTestCase):
         path.append(Aperture(20))
         self.assertEqual(path.imageSize(), inf)
 
-    def testFiniteImageSize(self):
-        path = ImagingPath()
-        path.append(Space(d=200))
-        path.append(Lens(f=50))
-        self.assertIsNotNone(path.imageSize())
-        self.assertTrue(np.isfinite(path.imageSize()))
 
     def testImageSizeInfinite(self):
         path = ImagingPath(System4f(f1=10, f2=2, diameter1=10))
         self.assertEqual(path.imageSize(), inf)
+
+    def testFiniteImageSizeWithObject(self):
+        path = ImagingPath()
+        path.append(Space(d=200))
+        path.append(Lens(f=50))
+        imageSize = path.imageSize(useObject=True)
+        self.assertIsNotNone(imageSize)
+        self.assertTrue(np.isfinite(imageSize))
+
+        imageSize = path.imageSize(useObject=False)
+        self.assertIsNotNone(imageSize)
+        self.assertTrue(not np.isfinite(imageSize))
 
     def testImageSize(self):
         path = ImagingPath(System4f(f1=10, f2=20, diameter1=10, diameter2=20))

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -165,6 +165,13 @@ class TestImagingPath(envtest.RaytracingTestCase):
         path.append(Aperture(20))
         self.assertEqual(path.imageSize(), inf)
 
+    def testFiniteImageSize(self):
+        path = ImagingPath()
+        path.append(Space(d=200))
+        path.append(Lens(f=50))
+        self.assertIsNotNone(path.imageSize())
+        self.assertTrue(np.isfinite(path.imageSize()))
+
     def testImageSizeInfinite(self):
         path = ImagingPath(System4f(f1=10, f2=2, diameter1=10))
         self.assertEqual(path.imageSize(), inf)

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -52,6 +52,7 @@ class TestImagingPath(envtest.RaytracingTestCase):
         mirror = CurvedMirror(10)
         path = ImagingPath([space, slab, mirror])
         self.assertTupleEqual(path.apertureStop(), (None, inf))
+        self.assertFalse(path.hasApertureStop())
 
     def testApertureStop(self):
         f1 = 10
@@ -59,6 +60,7 @@ class TestImagingPath(envtest.RaytracingTestCase):
         elements = [Space(f1), Lens(f1, 1000), Space(f1 + f2), Lens(f2, 700), Space(f2)]
         fourF = ImagingPath(elements)
         self.assertTupleEqual(fourF.apertureStop(), (40, 700))
+        self.assertTrue(fourF.hasApertureStop())
 
     def testApertureStopNamedTuple(self):
         f1 = 10
@@ -76,6 +78,7 @@ class TestImagingPath(envtest.RaytracingTestCase):
         elements = [space, tLens, space2, lens]
         path = ImagingPath(elements)
         self.assertTupleEqual(path.entrancePupil(), (None, None))
+        self.assertFalse(path.hasApertureStop())
 
     def testEntrancePupilAIs0(self):
         space = Space(2)
@@ -104,14 +107,18 @@ class TestImagingPath(envtest.RaytracingTestCase):
         space2 = Space(20)
         path = ImagingPath([space, lens, space2, lens, space])
         self.assertTupleEqual(path.fieldStop(), fieldStop)
+        self.assertFalse(path.hasFieldStop())
+        self.assertFalse(path.hasApertureStop())
 
-    def testFieldStopFiniteDiameter(self):
+    def testFieldStopInfiniteDiameterWithOneFiniteDiameter(self):
         fieldStop = (None, inf)
         space = Space(10)
         lens = Lens(10)
         space2 = Space(20)
-        path = ImagingPath([Lens(10, 450), space2, lens, space])
+        path = ImagingPath([Lens(f=10, diameter=450), space2, lens, space])
         self.assertTupleEqual(path.fieldStop(), fieldStop)
+        self.assertFalse(path.hasFieldStop())
+        self.assertTrue(path.hasApertureStop())
 
     def testFieldStop_1(self):
         space = Space(10)
@@ -120,6 +127,7 @@ class TestImagingPath(envtest.RaytracingTestCase):
         lens2 = Lens(10, 50)
         path = ImagingPath([space, lens, space2, lens2, space])
         self.assertTupleEqual(path.fieldStop(), (10, 100))
+        self.assertTrue(path.hasFieldStop())
 
     def testFieldStop_2(self):
         space = Space(10)
@@ -128,6 +136,7 @@ class TestImagingPath(envtest.RaytracingTestCase):
         lens2 = Lens(10, 50)
         path = ImagingPath([space, lens, space2, lens2, space])
         self.assertTupleEqual(path.fieldStop(), (30, 50))
+        self.assertTrue(path.hasFieldStop())
 
     def testFieldStopNamedTuple(self):
         space = Space(10)
@@ -137,6 +146,7 @@ class TestImagingPath(envtest.RaytracingTestCase):
         path = ImagingPath([space, lens, space2, lens2, space])
         self.assertEqual(path.fieldStop().z, 30)
         self.assertEqual(path.fieldStop().diameter, 50)
+        self.assertTrue(path.hasFieldStop())
 
     def testEntrancePupilNoBackwardConjugate(self):
         path = ImagingPath()


### PR DESCRIPTION
As discussed in #403, `imageSize` does not necessarily behave as expected for beginners.  

I added a default argument `useObject=False` to force the use of `self.objectHeight` instead of the field of view.  I print a warning to tell the user what to do when the FOV is infinite.