### PR TITLE
GRIN lenses

### DIFF
--- a/raytracing/examples/ex14.py
+++ b/raytracing/examples/ex14.py
@@ -22,7 +22,7 @@ def exampleCode(comments=None):
     path.append(obj)
     path.append(Space(10))
     
-    path.displayWithObject(diameter=20, fanAngle=0.005, comments=comments)
+    path.displayWithObject(diameter=10, fanAngle=0.005, comments=comments)
 
 if __name__ == "__main__":
     exampleCode()

--- a/raytracing/examples/ex20.py
+++ b/raytracing/examples/ex20.py
@@ -1,18 +1,20 @@
-TITLE       = "GRIN lens"
-DESCRIPTION = """
-A GRIN lens is available.  It has a quadratic index of refraction and is defined
-either with its alpha parameter or its pitch (it is easier to work with the pitch).
-Here, we have a GRIN available from Thorlabs G1P10.  Please note that the GRIN
-is not assumed to be in any medium.  Therefore, if you wish to use it in air or water
-(or both at either end), you need to explicitly add a DielectricInterface with the
-appropriate indices.
+TITLE       = "GRIN lens (example is Thorlabs G1P10"
+
+DESCRIPTION = """ 
+A GRIN lens is available.  It has a quadratic index of
+refraction and is defined either with its alpha parameter or its pitch (it is
+easier to work with the pitch). Here, we have a GRIN available from Thorlabs
+G1P10.  Please note that the GRIN is not assumed to be in any medium
+(air, water, etc..).  Therefore, if you wish to use it in air or water
+(or both at either end), you need to explicitly add a DielectricInterface
+with the appropriate indices before an after (as shown below).
 """
 
 from raytracing import *
 
 def exampleCode(comments=None):
     path = ImagingPath()
-
+    path.label = TITLE
     n0 = 1.66
     path.append(Space(d=0.2))
     # Dry side on the objective side (index is 1.0)

--- a/raytracing/examples/ex20.py
+++ b/raytracing/examples/ex20.py
@@ -1,0 +1,27 @@
+TITLE       = "GRIN lens"
+DESCRIPTION = """
+A GRIN lens is available.  It has a quadratic index of refraction and is defined
+either with its alpha parameter or its pitch (it is easier to work with the pitch).
+Here, we have a GRIN available from Thorlabs G1P10.  Please note that the GRIN
+is not assumed to be in any medium.  Therefore, if you wish to use it in air or water
+(or both at either end), you need to explicitly add a DielectricInterface with the
+appropriate indices.
+"""
+
+from raytracing import *
+
+def exampleCode(comments=None):
+    path = ImagingPath()
+
+    n0 = 1.66
+    path.append(Space(d=0.2))
+    # Dry side on the objective side (index is 1.0)
+    path.append(DielectricInterface(n1=1, n2=n0, diameter=1))
+    path.append(GRIN(L=3.758, n0=n0, pitch=0.433, diameter=1))
+    # Water immersion side on the sample side (index is 1.33)
+    path.append(DielectricInterface(n1=n0, n2=1.33, diameter=1))
+    path.append(Space(d=0.2))
+    path.displayWithObject(diameter=0.5, comments=comments)
+
+if __name__ == "__main__":
+    exampleCode()

--- a/raytracing/graphics.py
+++ b/raytracing/graphics.py
@@ -453,11 +453,11 @@ class GraphicOf:
         instance = type(element).__name__
         if type(element) is Objective or issubclass(type(element), Objective):
             return ObjectiveGraphic(element, x=x)
-        if instance is 'Lens':
+        if instance == 'Lens':
             return LensGraphic(element, x=x, minSize=minSize)
-        if instance is 'Space':
+        if instance == 'Space':
             return None
-        if instance is 'Aperture':
+        if instance == 'Aperture':
             return ApertureGraphic(element, x=x)
         if element.surfaces:
             return SurfacesGraphic(element, x=x)

--- a/raytracing/graphics.py
+++ b/raytracing/graphics.py
@@ -152,7 +152,7 @@ class MatrixGraphic(Graphic):
         if halfHeight == float("+Inf"):
             halfHeight = self.matrix.displayHalfHeight()
 
-        return [Rectangle(xy=(self.x, -halfHeight), width=self.matrix.L, height=2*halfHeight)]
+        return [Rectangle(xy=(0, -halfHeight), width=self.matrix.L, height=2*halfHeight)]
 
     @property
     def apertureComponents(self):

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -626,7 +626,7 @@ class ImagingPath(MatrixGroup):
                     dy = dy * 1.5  # Keep going, go faster (different factor)
 
                 y += dy
-                print(y)
+                # print(outputChiefRay.y, outputChiefRay.isBlocked)
                 wasBlocked = outputChiefRay.isBlocked
                 if abs(y) > self.maxHeight and not wasBlocked:
                     return Stop(z=fieldStopPosition, diameter=fieldStopDiameter)
@@ -638,6 +638,7 @@ class ImagingPath(MatrixGroup):
                     fieldStopDiameter = ray.apertureDiameter
                     break
 
+        # print(fieldStopPosition, fieldStopDiameter)
         return Stop(z=fieldStopPosition, diameter=fieldStopDiameter)
 
     def hasFieldStop(self):

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -626,9 +626,11 @@ class ImagingPath(MatrixGroup):
                     dy = dy * 1.5  # Keep going, go faster (different factor)
 
                 y += dy
+                print(y)
                 wasBlocked = outputChiefRay.isBlocked
                 if abs(y) > self.maxHeight and not wasBlocked:
                     return Stop(z=fieldStopPosition, diameter=fieldStopDiameter)
+
 
             for ray in chiefRayTrace:
                 if ray.isBlocked:

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1977,8 +1977,8 @@ class GRIN(Matrix):
                             physicalLength=L,
                             frontVertex=0,
                             backVertex=L,
-                            frontIndex=1.0,
-                            backIndex=1.0,
+                            frontIndex=n0,
+                            backIndex=n0,
                             apertureDiameter=diameter,
                             label=label)
         else:
@@ -1989,8 +1989,8 @@ class GRIN(Matrix):
                             physicalLength=L,
                             frontVertex=0,
                             backVertex=L,
-                            frontIndex=1.0,
-                            backIndex=1.0,
+                            frontIndex=n0,
+                            backIndex=n0,
                             apertureDiameter=diameter,
                             label=label)
 
@@ -2000,9 +2000,6 @@ class GRIN(Matrix):
         self.dz = L/20
         if self.pitch > 1:
             self.dz /= self.pitch
-
-
-
 
     def transferMatrix(self, upTo=float('+Inf')):
         """ Returns a Matrix() corresponding to a partial propagation

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1997,7 +1997,7 @@ class GRIN(Matrix):
         self.n0 = n0
         self.alpha = alpha
         self.pitch = pitch
-        self.dz = L/20
+        self.dz = L/20 # 20 pts per cycle
         if self.pitch > 1:
             self.dz /= self.pitch
 

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1945,15 +1945,15 @@ class GRIN(Matrix):
     Parameters
     ----------
     d : float
-        the length of the free space
+        the length of the GRIN
     n0 : float
-        The refraction index of the space. This value cannot be negative. (default=1)
+        The base refraction index of the GRIN. This value cannot be negative. (default=1)
     alpha : float
         The quadratic parameter for the index (default= None)
     pitch : float
         The pitch parameter of the the GRIN (number of oscillations alpha*L = 2*pi*pitch) (default=None)
     diameter: float
-        Diameter of element (default = infinity)
+        Diameter of GRIN (default = infinity)
     label : string
         The label of the free space
 
@@ -1969,17 +1969,31 @@ class GRIN(Matrix):
         elif pitch is None:
             pitch = alpha*L/2/pi
 
-        super().__init__(A=cos(alpha*L),
-                        B=1/alpha*sin(alpha*L),
-                        C=-alpha*sin(alpha*L),
-                        D=cos(alpha*L),
-                        physicalLength=L,
-                        frontVertex=0,
-                        backVertex=L,
-                        frontIndex=1.0,
-                        backIndex=1.0,
-                        apertureDiameter=diameter,
-                        label=label)
+        if alpha != 0:
+            super().__init__(A=cos(alpha*L),
+                            B=1/alpha*sin(alpha*L),
+                            C=-alpha*sin(alpha*L),
+                            D=cos(alpha*L),
+                            physicalLength=L,
+                            frontVertex=0,
+                            backVertex=L,
+                            frontIndex=1.0,
+                            backIndex=1.0,
+                            apertureDiameter=diameter,
+                            label=label)
+        else:
+            super().__init__(A=1,
+                            B=L,
+                            C=0,
+                            D=1,
+                            physicalLength=L,
+                            frontVertex=0,
+                            backVertex=L,
+                            frontIndex=1.0,
+                            backIndex=1.0,
+                            apertureDiameter=diameter,
+                            label=label)
+
         self.n0 = n0
         self.alpha = alpha
         self.pitch = pitch

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -518,7 +518,7 @@ class Matrix(object):
         elif self.L <= distance:
             return self
         else:
-            raise TypeError("Subclass of non-null physical length must override transferMatrix()")
+            raise TypeError("Subclass {0} of non-null physical length must override transferMatrix()".format(type(self)))
 
     def transferMatrices(self):
         """ The list of Matrix() that corresponds to the propagation through

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -75,8 +75,11 @@ class MatrixGroup(Matrix):
                     matrix.frontIndex = lastElement.backIndex
                     matrix.backIndex = matrix.frontIndex
                 else:
-                    msg = "Mismatch of indices between last element and appended element"
-                    raise ValueError(msg)
+                    msg = "Mismatch of indices between last element and appended element. "
+                    msg2 = "The last element ends with an index of n1={1}, ".format(lastElement.label, lastElement.backIndex)
+                    msg3 = "but the appended element has a front index of n2={1}. ".format(matrix.label, matrix.frontIndex)
+                    msg4 = "You must add a DielectricInterface(n1,n2) before (and DielectricInterface(n2,n1) after) the element."
+                    raise ValueError(msg+msg2+msg3+msg4)
 
         self.elements.append(matrix)
         transferMatrix = self.transferMatrix()

--- a/raytracing/matrixgroup.py
+++ b/raytracing/matrixgroup.py
@@ -311,7 +311,7 @@ class MatrixGroup(Matrix):
         ray formalism.  To find out if a ray has been blocked, you must
         use trace().
         """
-        transferMatrix = Matrix(A=1, B=0, C=0, D=1)
+        transferMatrix = Matrix(1,0,0,1, physicalLength=0)
         distance = upTo
         for element in self.elements:
             if element.L <= distance:

--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -331,6 +331,36 @@ class SingletLens(CompoundLens):
                 SphericalInterface(R=self.R2)]
 
 
+class PP1ToPP2(Matrix):
+    def __init__(self, physicalLength, diameter=float('+Inf'), label='PP1 to PP2'):
+        super().__init__(A=1, B=0, C=0, D=1,
+                         physicalLength=physicalLength,
+                         apertureDiameter=diameter,
+                         frontVertex=None,
+                         backVertex=None,
+                         label=label)
+    def transferMatrix(self, upTo=float('+Inf')):
+        """ Returns a Matrix() corresponding to a partial propagation
+        if the requested distance is smaller than the length of this element
+
+        Parameters
+        ----------
+        upTo : float
+            The length of the propagation (default=Inf)
+
+        Returns
+        -------
+        transferMatrix : object of class Matrix
+            the corresponding matrix to the propagation
+
+        """
+        distance = upTo
+        if distance < self.L:
+            return PP1ToPP2(physicalLength=distance, diameter=self.apertureDiameter)
+        else:
+            return self
+
+
 class Objective(MatrixGroup):
 
     """
@@ -382,7 +412,7 @@ class Objective(MatrixGroup):
 
         elements = [Aperture(diameter=self.backAperture, label="backAperture"),
                     Space(d=self.f),
-                    Matrix(1, 0, 0, 1, physicalLength=self.focusToFocusLength - 2 * self.f),
+                    PP1ToPP2(physicalLength=self.focusToFocusLength - 2 * self.f, diameter=self.backAperture),
                     Lens(f=self.f),
                     Space(d=self.f - self.workingDistance),
                     Aperture(diameter=self.frontAperture, label="frontAperture"),

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -121,12 +121,12 @@ class TestImagingPath(envtest.RaytracingTestCase):
         self.assertTrue(path.hasApertureStop())
 
     def testFieldStop_1(self):
-        space = Space(10)
-        lens = Lens(10, 100)
-        space2 = Space(20)
-        lens2 = Lens(10, 50)
+        space = Space(d=10)
+        lens = Lens(f=10, diameter=150)
+        space2 = Space(d=20)
+        lens2 = Lens(f=10, diameter=50)
         path = ImagingPath([space, lens, space2, lens2, space])
-        self.assertTupleEqual(path.fieldStop(), (10, 100))
+        self.assertTupleEqual(path.fieldStop(), (10, 150))
         self.assertTrue(path.hasFieldStop())
 
     def testFieldStop_2(self):

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -122,11 +122,12 @@ class TestImagingPath(envtest.RaytracingTestCase):
 
     def testFieldStop_1(self):
         space = Space(d=10)
-        lens = Lens(f=10, diameter=150)
+        lens = Lens(f=10, diameter=100)
         space2 = Space(d=20)
         lens2 = Lens(f=10, diameter=50)
         path = ImagingPath([space, lens, space2, lens2, space])
-        self.assertTupleEqual(path.fieldStop(), (10, 150))
+        path.display()
+        self.assertTupleEqual(path.fieldStop(), (10, 100))
         self.assertTrue(path.hasFieldStop())
 
     def testFieldStop_2(self):

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -677,8 +677,16 @@ f = +inf (afocal)
         g3 = GRIN(L=g2.L, n0=g2.n0, alpha=g2.alpha)
         self.assertEqual(g1.alpha, g3.alpha)
 
-    def testGrinWithoutGradient(self):
+    def testGrinWithoutGradientByAlpha(self):
         g = GRIN(L=10, n0=1., alpha=0)
+        s = Space(d=10)
+        self.assertEqual(g.A, s.A)
+        self.assertEqual(g.B, s.B)
+        self.assertEqual(g.C, s.C)
+        self.assertEqual(g.D, s.D)
+
+    def testGrinWithoutGradientByPitch(self):
+        g = GRIN(L=10, n0=1., pitch=0)
         s = Space(d=10)
         self.assertEqual(g.A, s.A)
         self.assertEqual(g.B, s.B)
@@ -702,6 +710,16 @@ f = +inf (afocal)
         g = GRIN(L=3.758, n0=1.66, pitch=0.5,diameter=10)
         path.append(g)
 
+    def testGrinRay(self):
+        path = ImagingPath()
+        n0 = 1.66
+        path.append(Space(d=0.2))
+        path.append(DielectricInterface(n1=1, n2=n0))
+        path.append(GRIN(L=3.758, n0=n0, pitch=0.433,diameter=10))
+        path.append(DielectricInterface(n1=n0, n2=1.33))
+        path.append(Space(d=0.3))
+        path.displayWithObject(diameter=5)
+        self.fail("The plot is off")
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -710,7 +710,7 @@ f = +inf (afocal)
         g = GRIN(L=3.758, n0=1.66, pitch=0.5,diameter=10)
         path.append(g)
 
-    def testGrinRay(self):
+    def testGrinRayPlot(self):
         path = ImagingPath()
         n0 = 1.66
         path.append(Space(d=0.2))
@@ -719,7 +719,6 @@ f = +inf (afocal)
         path.append(DielectricInterface(n1=n0, n2=1.33))
         path.append(Space(d=0.3))
         path.displayWithObject(diameter=5)
-        self.fail("The plot is off")
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -710,15 +710,19 @@ f = +inf (afocal)
         g = GRIN(L=3.758, n0=1.66, pitch=0.5,diameter=10)
         path.append(g)
 
+    def testGrinLargestDiameter(self):
+        g = GRIN(L=3.758, n0=1.66, pitch=0.433,diameter=1)
+        self.assertTrue(g.largestDiameter == 1)
+
     def testGrinRayPlot(self):
         path = ImagingPath()
         n0 = 1.66
         path.append(Space(d=0.2))
-        path.append(DielectricInterface(n1=1, n2=n0))
-        path.append(GRIN(L=3.758, n0=n0, pitch=0.433,diameter=10))
-        path.append(DielectricInterface(n1=n0, n2=1.33))
+        path.append(DielectricInterface(n1=1, n2=n0,diameter=1))
+        path.append(GRIN(L=3.758, n0=n0, pitch=0.433,diameter=1))
+        path.append(DielectricInterface(n1=n0, n2=1.33,diameter=1))
         path.append(Space(d=0.3))
-        path.displayWithObject(diameter=5)
+        path.displayWithObject(diameter=0.5)
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -267,6 +267,30 @@ class TestMatrix(envtest.RaytracingTestCase):
         with self.assertRaises(Exception) as context:
             m2.transferMatrix(upTo=0.5)
 
+
+    def testIncrementalTransferMatrixIsRightLength(self):
+        m = Space(d=10)
+        self.assertEqual(m.transferMatrix(), m)
+
+        mHalf = m.transferMatrix(startingAt=0, upTo=5)
+        self.assertEqual(mHalf.L*2, m.L)
+        
+        ray = Ray(y=0, theta=0.1)
+        outputRay = mHalf.trace(ray)
+
+        self.assertEqual(outputRay[0].z, 0)
+        self.assertEqual(outputRay[-1].z, mHalf.L)
+
+    def testTransferMatrixSumsUpToCompleteElementInfinite(self):
+        m = Space(d=10)
+        self.assertEqual(m.transferMatrix(), m)
+
+        ray = Ray(y=0, theta=0.1)
+
+        outputRay = m.trace(ray)
+        self.assertEqual(outputRay[0].z, 0)
+        self.assertEqual(outputRay[-1].z, m.L)
+
     def testTransferMatrices(self):
         m1 = Matrix(A=1, B=0, C=0, D=2, frontIndex=2)
         self.assertEqual(m1.transferMatrices(), [m1])
@@ -289,7 +313,7 @@ class TestMatrix(envtest.RaytracingTestCase):
         self.assertTrue(rayTrace[-1].z == 0)
 
     def testTraceBlocked(self):
-        ray = Ray(y=10, theta=1)
+        ray = Ray(y=11, theta=1)
         m = Space(d=10, diameter=10)
         trace = m.trace(ray)
         self.assertTrue(all(x.isBlocked for x in trace))
@@ -637,7 +661,7 @@ f = +inf (afocal)
 
     def testDisplayHalfHeightInfiniteDiameter(self):
         m = Matrix(apertureDiameter=inf)
-        self.assertEqual(m.displayHalfHeight(), 4)
+        self.assertEqual(m.displayHalfHeight(), 12.5)
 
     def testEqualityNotSameClassInstance(self):
         m = Matrix()
@@ -715,7 +739,7 @@ f = +inf (afocal)
         g = GRIN(L=3.758, n0=1.66, pitch=0.433,diameter=1)
         self.assertTrue(g.largestDiameter == 1)
 
-    #@patch('matplotlib.pyplot.show', new=Mock())
+    @patch('matplotlib.pyplot.show', new=Mock())
     def testGrinRayPlot(self):
         path = ImagingPath()
         n0 = 1.66

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -1,5 +1,6 @@
 import envtest  # modifies path
 import subprocess
+from unittest.mock import Mock, patch
 
 from raytracing import *
 
@@ -714,6 +715,7 @@ f = +inf (afocal)
         g = GRIN(L=3.758, n0=1.66, pitch=0.433,diameter=1)
         self.assertTrue(g.largestDiameter == 1)
 
+    @patch('matplotlib.pyplot.show', new=Mock())
     def testGrinRayPlot(self):
         path = ImagingPath()
         n0 = 1.66

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -658,6 +658,16 @@ f = +inf (afocal)
         space = Space(d)
         self.assertEqual(m, space)
 
+    def testGrin(self):
+        g = GRIN(d=10, n=1, n2=0.1)
+        # g.display()
+
+    def testGrinRay(self):
+        path = ImagingPath()
+        path.append(GRIN(d=10, n=1, n2=0.5,diameter=10))
+        path.display()
+
+
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -272,7 +272,7 @@ class TestMatrix(envtest.RaytracingTestCase):
 
     def testTrace(self):
         ray = Ray(y=1, theta=1)
-        m = Matrix(A=1, B=0, C=0, D=1, physicalLength=1)
+        m = Matrix(A=1, B=0, C=0, D=1, physicalLength=0)
         trace = [ray, m * ray]
         self.assertListEqual(m.trace(ray), trace)
 
@@ -284,13 +284,13 @@ class TestMatrix(envtest.RaytracingTestCase):
 
     def testTraceBlocked(self):
         ray = Ray(y=10, theta=1)
-        m = Matrix(A=1, B=0, C=0, D=1, apertureDiameter=10, physicalLength=1)
+        m = Space(d=10, diameter=10)
         trace = m.trace(ray)
         self.assertTrue(all(x.isBlocked for x in trace))
 
     def testTraceGaussianBeam(self):
         beam = GaussianBeam(w=1)
-        m = Matrix(A=1, B=0, C=0, D=1, apertureDiameter=10)
+        m = Space(d=10, diameter=10)
         outputBeam = m * beam
         tracedBeam = m.trace(beam)[-1]
         self.assertEqual(tracedBeam.w, outputBeam.w)
@@ -307,19 +307,19 @@ class TestMatrix(envtest.RaytracingTestCase):
 
     def testTraceMany(self):
         rays = [Ray(y, theta) for y, theta in zip(range(10, 20), range(10))]
-        m = Matrix(physicalLength=1.01)
+        m = Space(d=1.01)
         traceMany = [[ray, ray] for ray in rays]
         self.assertListEqual(m.traceMany(rays), traceMany)
 
     def testTraceManyJustOne(self):
         rays = [Ray()]
-        m = Matrix(physicalLength=1e-9)
+        m = Space(d=1e-9)
         traceMany = [rays * 2]
         self.assertListEqual(m.traceMany(rays), traceMany)
 
     def testTraceManyThroughIterable(self):
         rays = [Ray(y, y) for y in range(10)]
-        m = Matrix(physicalLength=1)
+        m = Space(d=1)
         iterable = tuple(rays)
         raysObj = Rays(iterable)
 
@@ -338,12 +338,12 @@ class TestMatrix(envtest.RaytracingTestCase):
 
     def testTraceManyThroughOutput(self):
         rays = [Ray(y, y) for y in range(10_000)]
-        m = Matrix(physicalLength=1)
+        m = Space(d=1)
         self.assertPrints(m.traceManyThrough, "Progress 10000/10000 (100%)", inputRays=rays, progress=True)
 
     def testTraceManyThroughNoOutput(self):
         rays = [Ray(y, y) for y in range(10_000)]
-        m = Matrix(physicalLength=1)
+        m = Space(d=1)
         self.assertPrints(m.traceManyThrough, "", inputRays=rays, progress=False)
 
     def testTraceManyThroughLastRayBlocked(self):
@@ -359,7 +359,7 @@ class TestMatrix(envtest.RaytracingTestCase):
     # Some information here: https://github.com/gammapy/gammapy/issues/2453
     def testTraceManyThroughInParallel(self):
         rays = [Ray(y, y) for y in range(5)]
-        m = Matrix(physicalLength=1)
+        m = Space(d=1)
         trace = self.assertDoesNotRaise(m.traceManyThroughInParallel, None, rays)
         for i in range(len(rays)):
             # Order is not kept, we have to check if the ray traced is in the original list
@@ -370,7 +370,7 @@ class TestMatrix(envtest.RaytracingTestCase):
     # Some information here: https://github.com/gammapy/gammapy/issues/2453
     def testTraceManyThroughInParallel(self):
         rays = [Ray(y, y) for y in range(5)]
-        m = Matrix(physicalLength=1)
+        m = Space(d=1)
         trace = self.assertDoesNotRaise(m.traceManyThroughInParallel, None, rays, processes=2)
         for i in range(len(rays)):
             # Order is not kept, we have to check if the ray traced is in the original list
@@ -659,12 +659,12 @@ f = +inf (afocal)
         self.assertEqual(m, space)
 
     def testGrin(self):
-        g = GRIN(d=10, n=1, n2=0.1)
-        # g.display()
+        g = GRIN(L=10, n0=1, n2=0.1)
+        # g.display()sub
 
     def testGrinRay(self):
         path = ImagingPath()
-        path.append(GRIN(d=10, n=1, n2=0.5,diameter=10))
+        path.append(GRIN(L=10, n0=1, n2=0.5,diameter=10))
         path.display()
 
 

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -715,7 +715,7 @@ f = +inf (afocal)
         g = GRIN(L=3.758, n0=1.66, pitch=0.433,diameter=1)
         self.assertTrue(g.largestDiameter == 1)
 
-    @patch('matplotlib.pyplot.show', new=Mock())
+    #@patch('matplotlib.pyplot.show', new=Mock())
     def testGrinRayPlot(self):
         path = ImagingPath()
         n0 = 1.66

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -669,25 +669,38 @@ f = +inf (afocal)
         space = Space(d)
         self.assertEqual(m, space)
 
-    def testGrin(self):
+    def testGrinInit(self):
         g1 = GRIN(L=3.758, n0=1.66, alpha=0.724)
         g2 = GRIN(L=3.758, n0=1.66, pitch=g1.pitch)
         self.assertEqual(g1,g2)
+
         g3 = GRIN(L=g2.L, n0=g2.n0, alpha=g2.alpha)
         self.assertEqual(g1.alpha, g3.alpha)
+
+    def testGrinWithoutGradient(self):
+        g = GRIN(L=10, n0=1., alpha=0)
+        s = Space(d=10)
+        self.assertEqual(g.A, s.A)
+        self.assertEqual(g.B, s.B)
+        self.assertEqual(g.C, s.C)
+        self.assertEqual(g.D, s.D)
+
+    # def testGrinWithoutGradientBaseIndexNot1(self):
+    #     g = GRIN(L=10, n0=1.5, alpha=0)
+    #     s = DielectricSlab(thickness=10,n=1.5)
+    #     self.assertEqual(g.A, s.A)
+    #     self.assertEqual(g.B, s.B)
+    #     self.assertEqual(g.C, s.C)
+    #     self.assertEqual(g.D, s.D)
 
     def testGrinRay(self):
         path = ImagingPath()
         g = GRIN(L=3.758, n0=1.66, alpha=0.724,diameter=10)
         path.append(g)
-        # path.display()
         
-
         path = ImagingPath()
         g = GRIN(L=3.758, n0=1.66, pitch=0.5,diameter=10)
         path.append(g)
-
-        # path.display()
 
 
 if __name__ == '__main__':

--- a/raytracing/tests/testsMatrixGroup.py
+++ b/raytracing/tests/testsMatrixGroup.py
@@ -210,7 +210,7 @@ class TestMatrixGroup(envtest.RaytracingTestCase):
         mg = MatrixGroup([s, l])
         trace = [ray, ray, Ray(6, 2), Ray(6, 1)]
         mgTrace = mg.trace(ray)
-        self.assertEqual(len(mgTrace), 4)
+        # self.assertEqual(len(mgTrace), 4)
         self.assertListEqual(mgTrace, trace)
         self.assertTrue(mgTrace[-1].isBlocked)
         self.assertListEqual(mg._lastRayTrace, trace)

--- a/raytracing/tests/traceManyThroughInParallelNoOutput.py
+++ b/raytracing/tests/traceManyThroughInParallelNoOutput.py
@@ -4,5 +4,5 @@ from raytracing import *
 
 if __name__ == '__main__':
     rays = [Ray(y, y) for y in range(20_000)]
-    m = Matrix(physicalLength=1)
+    m = Space(d=1)
     m.traceManyThroughInParallel(rays, processes=2, progress=False)

--- a/raytracing/tests/traceManyThroughInParallelWithOutput.py
+++ b/raytracing/tests/traceManyThroughInParallelWithOutput.py
@@ -4,5 +4,5 @@ from raytracing import *
 
 if __name__ == '__main__':
     rays = [Ray(y, y) for y in range(20_000)]
-    m = Matrix(physicalLength=1)
+    m = Space(d=1)
     m.traceManyThroughInParallel(rays, processes=2, progress=True)


### PR DESCRIPTION
Added a new element, the GRIN lens (gradient index lens).

It is fairly trivial to add, because the matrix is known.  The difficulty was mainly because drawing the element requires to split it in smaller chunks to see the trajectory of the ray properly because it evolves as it propagates. There is now a new variable in Matrix `dz` that indicates the preferred distance with computing the transfer matrices.  They all are `0` or `self.L` except for the GRIN.

I had to modify a few tests for `testsMatrix.py` because they made assumptions on the rayTraces but really should not assume any number of rays.  Only start and end are predictable.