### PR TITLE
Aperture NA

### DIFF
--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -65,7 +65,7 @@ Element = Matrix
 Group = MatrixGroup
 OpticalPath = ImagingPath
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 __author__ = "Daniel Cote <dccote@cervo.ulaval.ca>"
 
 import os.path as path

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -127,6 +127,7 @@ class Matrix(object):
             frontIndex=1.0,
             backIndex=1.0,
             apertureDiameter=float('+Inf'),
+            apertureNA=float('+Inf'),
             label=''
     ):
         # Ray matrix formalism
@@ -141,6 +142,9 @@ class Matrix(object):
         if apertureDiameter <= 0:
             raise ValueError("The aperture diameter must be strictly positive.")
         self.apertureDiameter = apertureDiameter
+        if apertureNA <= 0:
+            raise ValueError("The aperture NA must be strictly positive.")
+        self.apertureNA = apertureNA
 
         # First and last interfaces. Used for BFL and FFL
         self.frontVertex = frontVertex

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -396,7 +396,7 @@ class Matrix(object):
             outputRay.z = self.L + rightSideRay.z
             outputRay.apertureDiameter = self.apertureDiameter
 
-            if abs(rightSideRay.y) > self.apertureDiameter/2:
+            if abs(rightSideRay.y) > self.apertureDiameter/2 or abs(rightSideRay.theta) > self.apertureNA:
                 outputRay.isBlocked = True
             else:
                 outputRay.isBlocked = rightSideRay.isBlocked
@@ -1954,7 +1954,7 @@ class Aperture(Matrix):
     If the ray is beyond the finite diameter, the ray is blocked.
     """
 
-    def __init__(self, diameter, label=''):
+    def __init__(self, diameter, NA=float("+inf"), label=''):
         super(
             Aperture,
             self).__init__(
@@ -1964,4 +1964,5 @@ class Aperture(Matrix):
             D=1,
             physicalLength=0,
             apertureDiameter=diameter,
+            apertureNA=NA,
             label=label)

--- a/raytracing/tests/testsExamples.py
+++ b/raytracing/tests/testsExamples.py
@@ -22,6 +22,7 @@ class TestExamples(envtest.RaytracingTestCase):
         import raytracing.examples as ex
         self.assertTrue(len(ex.short) > 0)
 
+    @envtest.skipUnless(envtest.performanceTests, "Skipping long performance tests")
     @patch('matplotlib.pyplot.show', new=Mock())
     def testExamplesRun(self):
         import raytracing.examples as ex

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -27,6 +27,49 @@ class TestMatrix(envtest.RaytracingTestCase):
         with self.assertRaises(ValueError):
             Matrix(apertureDiameter=-0.1)
 
+    def testNullApertureNA(self):
+        with self.assertRaises(ValueError):
+            Matrix(apertureNA=0)
+
+    def testNonNullBlockingApertureNA(self):
+        m = Matrix(1,0,0,1,apertureNA=0.25)
+        ray = Ray(y=0, theta=0.5)
+        outRay = m*ray
+        self.assertTrue(outRay.isBlocked)
+
+    def testNonNullNonBlockingApertureNA(self):
+        m = Matrix(1,0,0,1,apertureNA=0.5)
+        ray = Ray(y=0, theta=0.25)
+        outRay = m*ray
+        self.assertFalse(outRay.isBlocked)
+
+    def testNonNullJustAtTheLimitApertureNA(self):
+        m = Matrix(1,0,0,1,apertureNA=0.5)
+        ray = Ray(y=0, theta=0.5)
+        outRay = m*ray
+        self.assertFalse(outRay.isBlocked)
+
+    def testApertureWithNA(self):
+        m = Aperture(diameter=1.0, NA=0.5)
+        ray = Ray(y=0, theta=0.6)
+        outRay = m*ray
+        self.assertTrue(outRay.isBlocked)
+
+        m = Aperture(diameter=0.5, NA=0.5)
+        ray = Ray(y=1.0, theta=0)
+        outRay = m*ray
+        self.assertTrue(outRay.isBlocked)
+
+        m = Aperture(diameter=0.5, NA=0.5)
+        ray = Ray(y=1.0, theta=0.6)
+        outRay = m*ray
+        self.assertTrue(outRay.isBlocked)
+
+        m = Aperture(diameter=0.5*2, NA=0.5)
+        ray = Ray(y=0.5, theta=0.5)
+        outRay = m*ray
+        self.assertFalse(outRay.isBlocked)
+
     def testMatrixExplicit(self):
         m = Matrix(A=1, B=0, C=0, D=1, physicalLength=1,
                    frontVertex=0, backVertex=0, apertureDiameter=0.5)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ rm dist/*; python setup.py sdist bdist_wheel; python -m twine upload dist/*
 
 setuptools.setup(
     name="raytracing",
-    version="1.3.6",
+    version="1.3.7",
     url="https://github.com/DCC-Lab/RayTracing",
     author="Daniel Cote",
     author_email="dccote@cervo.ulaval.ca",


### PR DESCRIPTION
Simple addition: aperture now has an optional parameter NA which can act as a limiting NA for the rays. Therefore, you can for instance use an aperture with a finite diameter and finite NA to simulate an fibre optic.