### PR TITLE
Add abs to fNumber calculation

### DIFF
--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -378,7 +378,7 @@ class ImagingPath(MatrixGroup):
         if pupilDiameter is None:
             return None
 
-        return focalFront/pupilDiameter
+        return abs(focalFront/pupilDiameter)
 
     def NA(self):
         """This function returns the numerical aperture of the component


### PR DESCRIPTION
Sometimes, got negative f/# (which is not possible). Added an abs() to fNumber in imagingPath.py. 