### PR TITLE
Fix various display properties

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -31,10 +31,10 @@ class Figure:
 
         self.styles = dict()
         self.styles['default'] = {'rayColors': ['b', 'r', 'g'], 'lampRayColors': ['y'], 'onlyAxialRay': False,
-                                  'imageColor': 'r', 'objectColor': 'b', 'onlyPrincipalAndAxialRays': True,
-                                  'limitObjectToFieldOfView': True, 'removeBlockedRaysCompletely': False,
-                                  'fontScale': 1.2, 'showFOV': False, 'showObjectImage': True,
-                                  'FOVColors': ['blue', 'red']}
+                                  'imageColor': 'r', 'fillImage': True, 'objectColor': 'b', 'fillObject': True,
+                                  'onlyPrincipalAndAxialRays': True, 'limitObjectToFieldOfView': True,
+                                  'removeBlockedRaysCompletely': False, 'fontScale': 1.2, 'showFOV': False,
+                                  'showObjectImage': True, 'FOVColors': ['blue', 'red']}
         self.styles['publication'] = self.styles['default'].copy()
         self.styles['presentation'] = self.styles['default'].copy()  # same as default for now
         self.styles['publication'].update({'rayColors': ['0.4', '0.2', '0.6'],
@@ -58,7 +58,8 @@ class Figure:
 
     def design(self, style: str = None,
                rayColors: List[Union[str, tuple]] = None, onlyAxialRay: bool = None,
-               imageColor: Union[str, tuple] = None, objectColor: Union[str, tuple] = None,
+               imageColor: Union[str, tuple] = None, fillImage: bool = None,
+               objectColor: Union[str, tuple] = None, fillObject: bool = None,
                fontScale: float = None, lampRayColors: List[Union[str, tuple]] = None,
                FOVColors: list = None, showObjectImage: bool = None):
         """ Update the design parameters of the figure.
@@ -79,6 +80,10 @@ class Figure:
             Color of image arrows. Default to 'r'.
         objectColor : Union[str, tuple], optional
             Color of object arrow. Default to 'b'.
+        fillImage : bool, optional
+            Fill the image arrows. Default to True.
+        fillObject : bool, optional
+            Fill the object arrow. Default to True.
         FOVColors: list
             The 2 colors to use for the graphics of FOV.
         fontScale : float, optional
@@ -94,6 +99,7 @@ class Figure:
 
         newDesignParams = {'rayColors': rayColors, 'onlyAxialRay': onlyAxialRay,
                            'imageColor': imageColor, 'objectColor': objectColor,
+                           'fillImage': fillImage, 'fillObject': fillObject,
                            'fontScale': fontScale, 'lampRayColors': lampRayColors,
                            'FOVColors': FOVColors, 'showObjectImage': showObjectImage}
         for key, value in newDesignParams.items():
@@ -200,13 +206,14 @@ class Figure:
             instance = type(rays).__name__
             if instance is 'ObjectRays':
                 objectKey = kObjectImageZKey.format(rays.z) if rays.z != 0 else kObjectImageKey
-                color = 'b' if rays.color is None else rays.color
-                self.graphicGroups[objectKey] = [ObjectGraphic(rays.yMax * 2, x=rays.z, color=color, label=rays.label)]
-                if rays.color is None:
-                    self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays.z))
-                else:
+                if self.path.showObject:
+                    self.graphicGroups[objectKey] = [ObjectGraphic(rays.yMax * 2, x=rays.z,
+                                                                   color=self.designParams['objectColor'],
+                                                                   fill=self.designParams['fillObject'], label=rays.label)]
+                if self.path.showImages:
                     self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays.z,
-                                                                                        fill=False, color=color))
+                                                                                        color=self.designParams['imageColor'],
+                                                                                        fill=self.designParams['fillImage']))
             if instance is 'LampRays':
                 lampKey = 'Lamp (z={0:.2f})'.format(rays.z) if rays.z != 0 else kLampKey
                 self.graphicGroups[lampKey] = [LampGraphic(rays.yMax * 2, x=rays.z, label=rays.label)]

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -204,7 +204,7 @@ class Figure:
     def setGraphicsFromRaysList(self):
         for rays in self.raysList:
             instance = type(rays).__name__
-            if instance is 'ObjectRays':
+            if instance == 'ObjectRays':
                 objectKey = kObjectImageZKey.format(rays.z) if rays.z != 0 else kObjectImageKey
                 if self.path.showObject:
                     self.graphicGroups[objectKey] = [ObjectGraphic(rays.yMax * 2, x=rays.z,
@@ -214,7 +214,7 @@ class Figure:
                     self.graphicGroups[objectKey].extend(self.graphicsOfConjugatePlanes(rays.yMax * 2, x=rays.z,
                                                                                         color=self.designParams['imageColor'],
                                                                                         fill=self.designParams['fillImage']))
-            if instance is 'LampRays':
+            if instance == 'LampRays':
                 lampKey = 'Lamp (z={0:.2f})'.format(rays.z) if rays.z != 0 else kLampKey
                 self.graphicGroups[lampKey] = [LampGraphic(rays.yMax * 2, x=rays.z, label=rays.label)]
 
@@ -223,12 +223,12 @@ class Figure:
             rayTrace = self.rayTraceLines(rays=rays)
 
             instance = type(rays).__name__
-            if instance is 'ObjectRays':
+            if instance == 'ObjectRays':
                 if rays.z == 0:
                     self.lineGroups[kObjectImageKey].extend(rayTrace)
                 else:
                     self.lineGroups[kObjectImageZKey.format(rays.z)] = rayTrace
-            elif instance is 'LampRays':
+            elif instance == 'LampRays':
                 self.designParams['showObjectImage'] = False
                 if rays.z == 0:
                     self.lineGroups[kLampKey].extend(rayTrace)
@@ -386,7 +386,7 @@ class Figure:
                 dz = rays.z
             if rays.rayColors is not None:
                 colors = rays.rayColors
-            elif type(rays).__name__ is 'LampRays':
+            elif type(rays).__name__ == 'LampRays':
                 colors = self.designParams['lampRayColors']
 
         if dz != 0:
@@ -548,7 +548,7 @@ class Figure:
         if not self.designParams['showObjectImage']:
             self.setGroupVisibility(kObjectImageKey, False)
 
-        if backend is 'matplotlib':
+        if backend == 'matplotlib':
             mplFigure = self.mplFigure
             mplFigure.create(comments, title)
             if display3D:
@@ -566,7 +566,7 @@ class Figure:
             self.lineGroups['rays'].extend(self.beamTraceLines(beam))
             self.annotations.extend(self.beamWaistAnnotations(beam))
 
-        if backend is 'matplotlib':
+        if backend == 'matplotlib':
             mplFigure = self.mplFigure
             mplFigure.create(comments, title)
             if display3D:

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -190,6 +190,9 @@ class Figure:
             elif graphic is not None:
                 graphics.append(graphic)
             z += element.L
+        if not self.path.showElementLabels:
+            for graphic in graphics:
+                graphic.label = None
         return graphics
 
     def setGraphicsFromRaysList(self):

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -300,7 +300,8 @@ class Figure:
         points = []
         halfHeight = self.displayRange / 2
         for zStr, label in labels.items():
-            points.append(Point(text=label, x=float(zStr), y=-halfHeight * 0.5, fontsize=12))
+            text = label if self.path.showPointsOfInterestLabels else None
+            points.append(Point(text=text, x=float(zStr), y=-halfHeight * 0.5, fontsize=12))
         return points
 
     @property

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -60,7 +60,7 @@ class Figure:
                rayColors: List[Union[str, tuple]] = None, onlyAxialRay: bool = None,
                imageColor: Union[str, tuple] = None, objectColor: Union[str, tuple] = None,
                fontScale: float = None, lampRayColors: List[Union[str, tuple]] = None,
-               FOVColors: list = None):
+               FOVColors: list = None, showObjectImage: bool = None):
         """ Update the design parameters of the figure.
         All parameters are None by default to allow for the update of one parameter at a time.
 
@@ -83,6 +83,8 @@ class Figure:
             The 2 colors to use for the graphics of FOV.
         fontScale : float, optional
             Base scale factor for the size of all fonts used. Default to 1.
+        showObjectImage : bool, optional
+            Set visibility of ObjectRays. Default to True.
         """
         if style is not None:
             if style in self.styles.keys():
@@ -93,7 +95,7 @@ class Figure:
         newDesignParams = {'rayColors': rayColors, 'onlyAxialRay': onlyAxialRay,
                            'imageColor': imageColor, 'objectColor': objectColor,
                            'fontScale': fontScale, 'lampRayColors': lampRayColors,
-                           'FOVColors': FOVColors}
+                           'FOVColors': FOVColors, 'showObjectImage': showObjectImage}
         for key, value in newDesignParams.items():
             if value is not None:
                 self.designParams[key] = value

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -678,7 +678,8 @@ class MplFigure(Figure):
     def drawPoints(self):
         for point in self.points:
             if point.hasPointMarker:
-                self.axes.plot([point.x], [0], 'ko', markersize=3, color=point.color, linewidth=0.4)
+                y = 0 if point.fixToAxis else point.y
+                self.axes.plot([point.x], [y], 'ko', markersize=3, color=point.color, linewidth=0.4)
             if point.text is not None:
                 point.fontsize *= self.fontScale
                 self.labels.append(point)

--- a/raytracing/graphicComponents.py
+++ b/raytracing/graphicComponents.py
@@ -462,7 +462,8 @@ class MplLabel(Label):
 
 
 class Point(Label):
-    def __init__(self, x=0.0, y=0.0, text=None, fontsize=12, color='k', hasMarker=True):
+    def __init__(self, x=0.0, y=0.0, text=None, fontsize=12, color='k', hasMarker=True, fixToAxis=True):
+        self.fixToAxis = fixToAxis
         super().__init__(text=text, x=x, y=y, fontsize=fontsize, hasPointMarker=hasMarker, color=color)
 
 

--- a/raytracing/graphics.py
+++ b/raytracing/graphics.py
@@ -453,11 +453,11 @@ class GraphicOf:
         instance = type(element).__name__
         if type(element) is Objective or issubclass(type(element), Objective):
             return ObjectiveGraphic(element, x=x)
-        if instance is 'Lens':
+        if instance == 'Lens':
             return LensGraphic(element, x=x, minSize=minSize)
-        if instance is 'Space':
+        if instance == 'Space':
             return None
-        if instance is 'Aperture':
+        if instance == 'Aperture':
             return ApertureGraphic(element, x=x)
         if element.surfaces:
             return SurfacesGraphic(element, x=x)

--- a/raytracing/graphics.py
+++ b/raytracing/graphics.py
@@ -1,6 +1,7 @@
 from raytracing.graphicComponents import *
 from .specialtylenses import Objective
 from .matrixgroup import MatrixGroup
+from .matrix import Space, Lens, Aperture
 import numpy as np
 
 
@@ -450,18 +451,19 @@ class ObjectiveGraphic(MatrixGroupGraphic):
 
 class GraphicOf:
     def __new__(cls, element, x=0.0, minSize=0) -> Union[MatrixGraphic, None, list]:
+        elementType = type(element)
         instance = type(element).__name__
-        if type(element) is Objective or issubclass(type(element), Objective):
+        if issubclass(elementType, Objective):
             return ObjectiveGraphic(element, x=x)
-        if instance == 'Lens':
+        if issubclass(elementType, Lens):
             return LensGraphic(element, x=x, minSize=minSize)
-        if instance == 'Space':
+        if issubclass(elementType, Space):
             return None
-        if instance == 'Aperture':
+        if issubclass(elementType, Aperture):
             return ApertureGraphic(element, x=x)
         if element.surfaces:
             return SurfacesGraphic(element, x=x)
-        if issubclass(type(element), MatrixGroup):
+        if issubclass(elementType, MatrixGroup):
             return MatrixGroupGraphic(element, x=x)
         else:
             return MatrixGraphic(element, x=x)

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -992,9 +992,9 @@ class ImagingPath(MatrixGroup):
 
         if 'ObjectRays' not in [type(rays).__name__ for rays in raysList]:
             if self.fanAngle is None:
-                self.fanAngle = np.tan(self.figure.displayRange / 2 / self.L / 5)
+                fanAngle = np.tan(self.figure.displayRange / 2 / self.L / 5)
             defaultObject = ObjectRays(self.objectHeight, z=self.objectPosition,
-                                       halfAngle=self.fanAngle, T=self.rayNumber, H=self.fanNumber)
+                                       halfAngle=fanAngle, T=self.rayNumber, H=self.fanNumber)
             raysList.append(defaultObject)
         else:
             self.figure.designParams['showObjectImage'] = True

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -48,7 +48,7 @@ class ImagingPath(MatrixGroup):
         The maximum height to be considered when calculating the field stop (default=10000.0)
     showObject : bool
         If True, the object will be shown on display (default=True)
-    showImage : bool
+    showImages : bool
         If True, the image will be shown on display (default=True)
     showEntrancePupil : bool
         If True, the entrance pupil will be shown on display (default=False)
@@ -58,8 +58,6 @@ class ImagingPath(MatrixGroup):
         If True, the points of interests will be shown on display (default=True)
     showPointsOfInterestLabels : bool
         If True, the labels of the points of interests will be shown on display (default=True)
-    showPlanesAcrossPointsOfInterest : bool
-        If True, the planes across the points of interests will be shown (default=True)
 
     Examples
     --------
@@ -100,13 +98,12 @@ class ImagingPath(MatrixGroup):
         # Display properties
         self.figure = Figure(opticalPath=self)
         self.design = self.figure.design
+        self.showEntrancePupil = False
+        self.showPointsOfInterest = True
         self.showObject = True
         self.showImages = True
-        self.showEntrancePupil = False
         self.showElementLabels = True
-        self.showPointsOfInterest = True
         self.showPointsOfInterestLabels = True
-        self.showPlanesAcrossPointsOfInterest = True
         super(ImagingPath, self).__init__(elements=elements, label=label)
 
     @property

--- a/raytracing/tests/testsImagingPath.py
+++ b/raytracing/tests/testsImagingPath.py
@@ -22,7 +22,6 @@ class TestImagingPath(envtest.RaytracingTestCase):
         self.assertTrue(path.showElementLabels)
         self.assertTrue(path.showPointsOfInterest)
         self.assertTrue(path.showPointsOfInterestLabels)
-        self.assertTrue(path.showPlanesAcrossPointsOfInterest)
         self.assertFalse(path.showEntrancePupil)
 
     def testImagingPathWithElements(self):


### PR DESCRIPTION
- Fixed a few display properties inside ImagingPath that were not linked to the Figure. 
- Fixed some design parameters that were not accessible from the design() method. 
- Added showObjectImage design parameter. Useful when using non-interactive display to hide the ObjectRays group. 
- Allow creation of Point(fixToAxis=False) objects that are not anchored to the Z-axis (still anchored by default). Useful if the user wants to draw custom points on the display.