### PR TITLE
Display of compound lens

### DIFF
--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -43,9 +43,15 @@ class CompoundLens(MatrixGroup):
 
     @property
     def forwardSurfaces(self) -> List[Interface]:
-        """ Must be overridden by subclasses """
-
-        return None
+        surfaces = []
+        spaceLength = 0
+        for element in reversed(self.elements):
+            if isinstance(element, Space):
+                spaceLength = element.L
+            elif isinstance(element, DielectricInterface):
+                surfaces.append(SphericalInterface(element.R, n=element.n2, L=spaceLength))
+        surfaces.reverse()
+        return surfaces
 
     def focalShifts(self, wavelengths=None):
         """ The chromatic aberration shifts to the focal distance from the
@@ -92,6 +98,7 @@ class CompoundLens(MatrixGroup):
     @classmethod
     def all(cls):
         return allSubclasses(cls)
+
 
 class AchromatDoubletLens(CompoundLens):
     """ 

--- a/raytracing/specialtylenses.py
+++ b/raytracing/specialtylenses.py
@@ -21,11 +21,12 @@ the Objective() class.
 """
 
 class CompoundLens(MatrixGroup):
-    def __init__(self, elements, designFocalLength, wavelengthRef=None, url=None, label=''):
+    def __init__(self, elements, designFocalLength, diameter=float("+Inf"), wavelengthRef=None, url=None, label=''):
         """ A base class for any lens that we make from its individual elements
         """
         super(CompoundLens, self).__init__(elements=elements, label=label)
 
+        self.apertureDiameter = diameter
         self.designFocalLength = designFocalLength
         self.url = url
         self.wavelengthRef = wavelengthRef
@@ -185,12 +186,11 @@ class AchromatDoubletLens(CompoundLens):
         elements.append(DielectricInterface(n1=self.n1, n2=self.n2, R=R2, diameter=diameter))
         elements.append(Space(d=tc2, n=self.n2))
         elements.append(DielectricInterface(n1=self.n2, n2=1, R=R3, diameter=diameter))
-        super(AchromatDoubletLens, self).__init__(elements=elements, 
+        super(AchromatDoubletLens, self).__init__(elements=elements, diameter=diameter,
                                                   designFocalLength=fa, 
                                                   wavelengthRef=wavelengthRef,
                                                   url=url, 
                                                   label=label)
-        self.apertureDiameter = diameter
 
         if abs(self.tc1 + self.tc2 - self.L) / self.L > 0.02:
             msg = "Obtained thickness {0:.4} is not within 2%% of expected {1:.4}".format(self.tc1 + self.tc2, self.L)
@@ -297,12 +297,11 @@ class SingletLens(CompoundLens):
         elements.append(Space(d=tc, n=self.n))
         elements.append(DielectricInterface(n1=self.n, n2=1, R=R2, diameter=diameter))
 
-        super(SingletLens, self).__init__(elements=elements, 
+        super(SingletLens, self).__init__(elements=elements, diameter=diameter,
                                           designFocalLength=f, 
                                           wavelengthRef=wavelengthRef,
                                           url=url, 
                                           label=label)
-        self.apertureDiameter = diameter
 
         if abs(self.tc - self.L) / self.L > 0.02:
             msg = "Obtained thickness {0:.4} is not within 2%% of expected {1:.4}".format(self.tc1, self.L)

--- a/raytracing/specifications/envtest.py
+++ b/raytracing/specifications/envtest.py
@@ -1,0 +1,151 @@
+import sys
+import os
+import io
+from contextlib import redirect_stdout, redirect_stderr
+import unittest
+import tempfile
+import matplotlib.pyplot as plt
+from unittest.mock import Mock, patch
+import numpy as np
+import warnings
+
+import io
+import contextlib
+
+#Use with patch('matplotlib.pyplot.show', new=Mock()):
+# or @patch('matplotlib.pyplot.show', new=Mock())
+
+perfTestKey = "RAYTRACING_PERF_TESTS"
+performanceTests = False
+if perfTestKey in os.environ:
+    performanceTests = os.environ[perfTestKey]
+else:
+    performanceTests = False
+
+class RaytracingTestCase(unittest.TestCase):
+    tempDir = os.path.join(tempfile.gettempdir(), "tempDir")
+    setupCalled = False
+    stdout = None
+    stderr = None
+    def __init__(self, tests=()):
+        super(RaytracingTestCase, self).__init__(tests)
+        warnings.simplefilter("ignore")
+
+    def setUp(self):
+        super().setUp()
+        warnings.simplefilter("ignore")
+
+        # Seed with same seed every time
+        np.random.seed(0)
+
+        self.setupCalled = True
+
+    def tearDown(self) -> None:
+        self.clearMatplotlibPlots()
+
+    def testProperlySetup(self):
+        self.assertTrue(self.setupCalled, msg="You must call super().setUp() in your own setUp()")
+
+    @classmethod
+    def clearMatplotlibPlots(cls):
+        plt.clf()
+        plt.cla()
+        plt.close()
+
+    def assertDoesNotRaise(self, func, exceptionType=None, *funcArgs, **funcKwargs):
+        returnValue = None
+        if exceptionType is None:
+            exceptionType = Exception
+        try:
+            returnValue = func(*funcArgs, **funcKwargs)
+        except exceptionType as e:
+            self.fail(f"An exception was raised:\n{e}")
+        # Don't handle exceptions not in exceptionType
+        return returnValue
+
+    def assertPrints(self, func, out, stripOutput: bool = True, *funcArgs, **funcKwargs):
+        @redirectStdOutToFile
+        def getOutput():
+            func(*funcArgs, **funcKwargs)
+
+        value = getOutput()
+        if stripOutput:
+            value = value.strip()
+        self.assertEqual(value, out)
+
+
+    @classmethod
+    def createTempDirectory(cls):
+        if os.path.exists(cls.tempDir):
+            cls.deleteTempDirectory()
+        os.mkdir(cls.tempDir)
+
+    @classmethod
+    def deleteTempDirectory(cls):
+        if os.path.exists(cls.tempDir):
+            for file in os.listdir(cls.tempDir):
+                os.remove(os.path.join(cls.tempDir, file))
+            os.rmdir(cls.tempDir)
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.createTempDirectory()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.deleteTempDirectory()
+
+    def tempFilePath(self, filename="temp.dat") -> str:
+        return os.path.join(RaytracingTestCase.tempDir, filename)
+
+
+def redirectStdOutToFile(_func=None, file=None, returnOnlyValue: bool = True):
+    if file is None:
+        file = io.StringIO()
+
+    def redirectStdOut(func):
+        def wrapperRedirectStdOut(*args, **kwargs):
+            with redirect_stdout(file):
+                func(*args, **kwargs)
+
+            return file.getvalue() if returnOnlyValue else file
+
+        return wrapperRedirectStdOut
+
+    if _func is None:
+        return redirectStdOut
+    return redirectStdOut(_func)
+
+
+def main():
+    unittest.main()
+
+
+def skip(reason: str):
+    return unittest.skip(reason)
+
+
+def skipIf(condition: object, reason: str):
+    return unittest.skipIf(condition, reason)
+
+
+def skipUnless(condition: object, reason: str):
+    return unittest.skipUnless(condition, reason)
+
+
+def expectedFailure(func):
+    return unittest.expectedFailure(func)
+
+def patchMatplotLib():
+    return patch('matplotlib.pyplot.show', new=Mock())
+     
+# append module root directory to sys.path
+sys.path.insert(0,
+                os.path.dirname(
+                    os.path.dirname(
+                        os.path.dirname(
+                            os.path.abspath(__file__)
+                        )
+                    )
+                )
+                )

--- a/raytracing/specifications/lensBuilder.py
+++ b/raytracing/specifications/lensBuilder.py
@@ -59,5 +59,6 @@ print("f = 9.006 mm")
 print("WD = 2.04 mm")
 
 olympus20xPrescription = CompoundLens(olympus20xPrescription.elements,
-                                      olympus20xPrescription.effectiveFocalLengths().f1)
+                                      designFocalLength=olympus20xPrescription.effectiveFocalLengths().f1,
+                                      diameter=20)
 olympus20xPrescription.display()

--- a/raytracing/specifications/lensBuilder.py
+++ b/raytracing/specifications/lensBuilder.py
@@ -57,3 +57,7 @@ print("--------------")
 print("From Olympus patent, Table 3, at https://patents.google.com/patent/US6501603B2/en")
 print("f = 9.006 mm")
 print("WD = 2.04 mm")
+
+olympus20xPrescription = CompoundLens(olympus20xPrescription.elements,
+                                      olympus20xPrescription.effectiveFocalLengths().f1)
+olympus20xPrescription.display()

--- a/raytracing/specifications/lensBuilder.py
+++ b/raytracing/specifications/lensBuilder.py
@@ -1,3 +1,4 @@
+import envtest
 import csv
 from raytracing import *
 


### PR DESCRIPTION
*Currently a draft until we make a decision about the fact that this PR requires some commits from the branch grinLenses. 

The file lensBuilder.py can now display the elements from prescription file using the CompoundLens class. 

- Added default forward surfaces in CompoundLens. 
- Added diameter argument to CompoundLens in order to correctly set apertureDiameter (default to infinity).

@dccote is this the figure you were expecting ?

![image](https://user-images.githubusercontent.com/29587649/169601050-5d485214-16e2-4f5f-bcb0-48403599255f.png)

### Limitations
- When trying to display the resulting CompoundLens inside an imaging path, it raises an error about the system matrix being ill-defined. 
- The resulting surface graphic is a bit off in the corners. See image:
![Screen Shot 2022-05-20 at 3 54 32 PM](https://user-images.githubusercontent.com/29587649/169601891-ec231ae3-e61d-4aa9-a452-9abd71077456.png)


