### PR TITLE
Version checking: We timestamp even when we fail: no need to keep checking

### DIFF
--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -65,7 +65,7 @@ Element = Matrix
 Group = MatrixGroup
 OpticalPath = ImagingPath
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 __author__ = "Daniel Cote <dccote@cervo.ulaval.ca>"
 
 import os.path as path
@@ -91,12 +91,14 @@ def checkLatestVersion():
                 print("Latest version {0} available on PyPi (you are using {1}).".format(latestVersion, __version__))
                 print("run `pip install --upgrade raytracing` to update.")
 
+    except Exception as err:
+        print("Unable to check for latest version of raytracing on pypi.org")
+        print(err)
+
+    finally:
+        # We always timestamp: if there was an error, we will not look again until later
         with open(checkFile, 'w') as opened_file:
             opened_file.write("Last check is timestamp of this file")
-
-    except Exception as err:
-        print(err)
-        print("Unable to check for latest version of raytracing on pypi.org")
 
 
 def lastCheckMoreThanADay():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ rm dist/*; python3 setup.py sdist bdist_wheel; python3 -m twine upload dist/*
 
 setuptools.setup(
     name="raytracing",
-    version="1.3.7",
+    version="1.3.8",
     url="https://github.com/DCC-Lab/RayTracing",
     author="Daniel Cote",
     author_email="dccote@cervo.ulaval.ca",


### PR DESCRIPTION
The module checks PyPI for a new version once per day at most.  This requires an internet connection, but if there is an error, we simply delay until the next day, no need to check again, it is not a big deal.