### PR TITLE
Preferences, better version check and convenience functions

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,47 @@
+# Frequently Asked Questions
+
+
+
+1. **What is the formalism used and where can I learn about it?**
+
+   We use the ray matrix formalism and you can learn about it in most optics books as well as in the publication:
+
+   > ["Tools and tutorial on practical ray tracing for microscopy"](https://doi.org/10.1117/1.NPh.8.1.010801) 
+   >
+   > by V. Pineau Noël\*, S. Masoumi\*, E. Parham*, G. Genest, L. Bégin, M.-A. Vigneault, D. C. Côté, 
+   > Neurophotonics, 8(1), 010801 (2021). 
+   > *Equal contributions.
+   > Permalink: https://doi.org/10.1117/1.NPh.8.1.010801
+
+   If you happen to speak French, D.C. Côté's Optique notes are available [online](https://books.apple.com/ca/book/optique/id949326768) and as PDF and there is a chapter on it.
+
+2. **Can you do spherical aberrations?**
+
+   No we cannot. It may appear at first sight that it is possible (we could easily correct the sinθ ≅ θ approximation when off-axis) but the ray matrix formalism does not allow us to consider the different propagation distances of the off-axis rays.  By definition, for exemple, a element of `Space` has a given length `d` and it is the same for all rays.  When considering spherical aberrations, this varying distance for rays that are off-axis is part of the aberration, which is not given solely by the correction to the angle.  Since we cannot have a different distance for all rays (i.e. it is a matrix multiplication), then spherical aberrations are not possible (as far as we know). ***You think we are wrong? Teach us how to do it!***
+
+3. **Can you do chromatic aberrations?**
+
+   Yes we can, when the lenses are built from dielectric interfaces and materials with `Materials`.  The Thorlabs and Edmund Optics lenses are built with a radius of curvature and the proper material as obtained from the excellent site http://refractiveindex.info.
+   It is not possible however to consider chromatic aberrations for a thin lens. The thin lens is created directly with a given focal length and no material at all (it is infinitely thin). The focal length is fixed. To create a lens with chromatic aberration, you need to use `SingletLens` or `AchromaticDoubletLens`.
+   
+4. **Can I perform more complex calculations than just tracing rays?**
+   Of course you can. Although the display functions are central to the module, you can also extract more information in a script.  For instance, the example [lsmConfocalPinhole.py](https://github.com/DCC-Lab/RayTracing/blob/master/raytracing/examples/fig6-lsmConfocalpinhole.py) is a good example. 
+
+5. **Can you perform a 2D efficiency calculation that will apply to my real-life optical system?**
+   Yes, but you need to use a ray distribution that considers the cylindrical symmetry (currently in preparation). This will provide proper numbers for the 2D energy efficiency, but it will not be "traceable" easily. To trace your rays, use the `RandomUniformRays` class for instance.
+
+6. **There are stored preferences. Where are they?**
+   It depends on the platform. The file is always the same (it is a JSON dictionary) but the location is obtained differently based on the platform:
+
+   * macOS: `(username)/Library/Preferences/ca.dcclab.python.raytracing.json`
+
+   * Windows: `(username)/AppData(something-something)/ca.dcclab.python.raytracing.json`
+
+   * linux:  `(username)/.config/ca.dcclab.python.raytracing.json`
+
+   
+   Some of the variables that are stored are: `lastVersionCheck` (date of the last version check on PyPI) and `mode` which can be `beginner`, `expert`, or `silent`.
+   
+7. **There are a lot of warnings printed on screen, and I don't like it because I know what I am doing. Can I get rid of that?**
+   Yes you can. There are three modes: `beginner` (many warnings), `expert` (very few, but some), and `silent` (nothing). Call `silentMode(saveToPrefs=True)` or `expertMode(saveToPrefs=True)` and you will be all set.
+

--- a/FAQ.md
+++ b/FAQ.md
@@ -25,13 +25,13 @@
    It is not possible however to consider chromatic aberrations for a thin lens. The thin lens is created directly with a given focal length and no material at all (it is infinitely thin). The focal length is fixed. To create a lens with chromatic aberration, you need to use `SingletLens` or `AchromaticDoubletLens`.
    
 4. **Can I perform more complex calculations than just tracing rays?**
-   Of course you can. Although the display functions are central to the module, you can also extract more information in a script.  For instance, the example [lsmConfocalPinhole.py](https://github.com/DCC-Lab/RayTracing/blob/master/raytracing/examples/fig6-lsmConfocalpinhole.py) is a good example. 
+   Of course you can. Although the display functions are central to the module, you can also extract more information in a script.  For instance, the example [lsmConfocalPinhole.py](https://github.com/DCC-Lab/RayTracing/blob/master/raytracing/examples/fig6-lsmConfocalpinhole.py) is a good example where the transmission efficacy of a pinhole is calculated as a function of distance from the focal plane.
 
 5. **Can you perform a 2D efficiency calculation that will apply to my real-life optical system?**
    Yes, but you need to use a ray distribution that considers the cylindrical symmetry (currently in preparation). This will provide proper numbers for the 2D energy efficiency, but it will not be "traceable" easily. To trace your rays, use the `RandomUniformRays` class for instance.
 
 6. **There are stored preferences. Where are they?**
-   It depends on the platform. The file is always the same (it is a JSON dictionary) but the location is obtained differently based on the platform:
+   Some variables can be "saved" into a Preferences file on disk.  Where it is depends on the platform. The file is always the same (it is a JSON dictionary) but the location is platform-specific:
 
    * macOS: `(username)/Library/Preferences/ca.dcclab.python.raytracing.json`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The code has been developed first for teaching purposes and is used in my "[Opti
 
 > ["Tools and tutorial on practical ray tracing for microscopy"](https://doi.org/10.1117/1.NPh.8.1.010801) 
 >
-> by V. Pineau Noël*, S. Masoumi*, E. Parham*, G. Genest, L. Bégin, M.-A. Vigneault, D. C. Côté, 
+> by V. Pineau Noël\*, S. Masoumi\*, E. Parham\*, G. Genest, L. Bégin, M.-A. Vigneault, D. C. Côté, 
 > Neurophotonics, 8(1), 010801 (2021). 
 > *Equal contributions.
 > Permalink: https://doi.org/10.1117/1.NPh.8.1.010801
@@ -32,6 +32,8 @@ If you want to perform calculations with coherent laser beams, then you use `Gau
 ## What's new?
 
 To get information about what is new, currently the best place is the [release page on GitHub.](https://github.com/DCC-Lab/RayTracing/releases)
+
+There is a **[Frequently Asked Questions](./FAQ.md)** page.
 
 The article above is fully compatible with all 1.3.x versions.  As long as the API does not change, versions will be 1.3.x.
 

--- a/docs/README-documentation.md
+++ b/docs/README-documentation.md
@@ -132,7 +132,7 @@ Defined pages in the website are the content of the following files:
 
 ### Build online
 The online documentation can be updated directly from the [RayTracing project](https://readthedocs.org/projects/raytracing/) on ReadTheDocs by the project administrators (currently dccote, jlbegin and elaheparham) to match the release from PyPI. The build is currently set on the master branch.
-To build a released version, an admistrator must go to the [Build](https://readthedocs.org/projects/raytracing/builds/) on ReadTheDocs, select the version and push Build Version. 
+To build a released version, an administrator must go to the [Build](https://readthedocs.org/projects/raytracing/builds/) on ReadTheDocs, select the version and push Build Version. 
 
 Remember before bulding online the new documentation version, you should check if all the documentations and examples are working properly. So, run `.../raytracing/tests/testsDocTestModule.py` and if there are no errors, the documentation is working properly. 
 If there is an error you should go to the line that raises the error and fix it before publishing the new version.

--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -62,7 +62,7 @@ Element = Matrix
 Group = MatrixGroup
 OpticalPath = ImagingPath
 
-__version__ = "1.3.8"
+__version__ = "1.3.9"
 __author__ = "Daniel Cote <dccote@cervo.ulaval.ca>"
 
 import os.path as path
@@ -81,7 +81,6 @@ def checkLatestVersion():
         url = "https://pypi.org/pypi/raytracing/json"
         req = urllib.request.Request(url)
         with urllib.request.urlopen(req, timeout=1) as response:
-            print("Here")
             data = json.load(response)
             versions = sorted(data["releases"].keys(),key=StrictVersion)
             latestVersion = versions[-1]

--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -49,6 +49,7 @@ from . import olympus
 from .zemax import *
 
 from .utils import *
+from .preferences import *
 
 import os
 
@@ -56,6 +57,7 @@ if "RAYTRACING_EXPERT" in os.environ:
     expertMode()
 else:
     beginnerMode()
+
     
 """ Synonym of Matrix: Element 
 
@@ -111,4 +113,17 @@ def lastCheckMoreThanADay():
 
 if lastCheckMoreThanADay():
     checkLatestVersion()
+
+variables = Preferences().readPreferences()
+try:
+
+    if "silentMode" in variables:
+        silentMode()
+    elif "expertMode" in variables:
+        expertMode()
+    else:
+        beginnerMode()
+except Exception as err:
+    pass
+
 

--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -69,9 +69,6 @@ import os.path as path
 import time
 import tempfile
 
-tmpDir = tempfile.gettempdir()
-checkFile = '{0}/raytracing-version-check'.format(tmpDir)
-
 def checkLatestVersion():
     try:
         import json
@@ -92,30 +89,23 @@ def checkLatestVersion():
         print("Unable to check for latest version of raytracing on pypi.org")
         print(err)
 
-    finally:
-        # We always timestamp: if there was an error, we will not look again until later
-        with open(checkFile, 'w') as opened_file:
-            opened_file.write("Last check is timestamp of this file")
-
-
 def lastCheckMoreThanADay():
     if "lastVersionCheck" in prefs:
-        then = datetime.date.fromisoformat(prefs["lastVersionCheck"])
+        then = datetime.fromisoformat(prefs["lastVersionCheck"])
         difference = datetime.now() - then
         if difference.days > 1:
             return True
         else:
             return False
     else:
-        prefs["lastVersionCheck"] = datetime.now().isoformat()
         return True
+
+prefs = Preferences()
 
 if "RAYTRACING_EXPERT" in os.environ:
     expertMode()
 else:
     beginnerMode()
-
-prefs = Preferences()
 
 if lastCheckMoreThanADay():
     checkLatestVersion()

--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -76,15 +76,15 @@ def checkLatestVersion():
     try:
         import json
         import urllib.request
-        from distutils.version import StrictVersion
+        from packaging.version import Version
 
         url = "https://pypi.org/pypi/raytracing/json"
         req = urllib.request.Request(url)
         with urllib.request.urlopen(req, timeout=1) as response:
             data = json.load(response)
-            versions = sorted(data["releases"].keys(),key=StrictVersion)
+            versions = [ Version(version) for version in data["releases"].keys() ]
             latestVersion = versions[-1]
-            if __version__ < latestVersion:
+            if Version(__version__) < latestVersion:
                 print("Latest version {0} available on PyPi (you are using {1}).".format(latestVersion, __version__))
                 print("run `pip install --upgrade raytracing` to update.")
 

--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -100,22 +100,19 @@ def lastCheckMoreThanADay():
     else:
         return True
 
+
 prefs = Preferences()
-
-if "RAYTRACING_EXPERT" in os.environ:
-    expertMode()
-else:
-    beginnerMode()
-
 if lastCheckMoreThanADay():
     checkLatestVersion()
     prefs["lastVersionCheck"] = datetime.now().isoformat()
+
+if "RAYTRACING_EXPERT" in os.environ:
+    prefs["mode"] = "expert"
     
 try:
-
-    if "silentMode" in prefs:
+    if prefs["mode"] == "silent":
         silentMode()
-    elif "expertMode" in prefs:
+    elif prefs["mode"] == "expert":
         expertMode()
     else:
         beginnerMode()

--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -69,26 +69,6 @@ import os.path as path
 import time
 import tempfile
 
-def checkLatestVersion():
-    try:
-        import json
-        import urllib.request
-        from packaging.version import Version
-
-        url = "https://pypi.org/pypi/raytracing/json"
-        req = urllib.request.Request(url)
-        with urllib.request.urlopen(req, timeout=1) as response:
-            data = json.load(response)
-            versions = [ Version(version) for version in data["releases"].keys() ]
-            latestVersion = versions[-1]
-            if Version(__version__) < latestVersion:
-                print("Latest version {0} available on PyPi (you are using {1}).".format(latestVersion, __version__))
-                print("run `pip install --upgrade raytracing` to update.")
-
-    except Exception as err:
-        print("Unable to check for latest version of raytracing on pypi.org")
-        print(err)
-
 def lastCheckMoreThanADay():
     if "lastVersionCheck" in prefs:
         then = datetime.fromisoformat(prefs["lastVersionCheck"])

--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -52,12 +52,7 @@ from .utils import *
 from .preferences import *
 
 import os
-
-if "RAYTRACING_EXPERT" in os.environ:
-    expertMode()
-else:
-    beginnerMode()
-
+from datetime import datetime
     
 """ Synonym of Matrix: Element 
 
@@ -85,7 +80,8 @@ def checkLatestVersion():
 
         url = "https://pypi.org/pypi/raytracing/json"
         req = urllib.request.Request(url)
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=1) as response:
+            print("Here")
             data = json.load(response)
             versions = sorted(data["releases"].keys(),key=StrictVersion)
             latestVersion = versions[-1]
@@ -102,24 +98,33 @@ def checkLatestVersion():
 
 
 def lastCheckMoreThanADay():
-    if path.exists(checkFile):
-        lastTime = path.getmtime(checkFile)
-        if time.time() - lastTime > 24*60*60:
+    if "lastVersionCheck" in prefs:
+        then = datetime.date.fromisoformat(prefs["lastVersionCheck"])
+        difference = datetime.now() - then
+        if difference.days > 1:
             return True
         else:
             return False
     else:
+        prefs["lastVersionCheck"] = datetime.now().isoformat()
         return True
+
+if "RAYTRACING_EXPERT" in os.environ:
+    expertMode()
+else:
+    beginnerMode()
+
+prefs = Preferences()
 
 if lastCheckMoreThanADay():
     checkLatestVersion()
-
-variables = Preferences().readPreferences()
+    prefs["lastVersionCheck"] = datetime.now().isoformat()
+    
 try:
 
-    if "silentMode" in variables:
+    if "silentMode" in prefs:
         silentMode()
-    elif "expertMode" in variables:
+    elif "expertMode" in prefs:
         expertMode()
     else:
         beginnerMode()

--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -65,7 +65,7 @@ Element = Matrix
 Group = MatrixGroup
 OpticalPath = ImagingPath
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 __author__ = "Daniel Cote <dccote@cervo.ulaval.ca>"
 
 import os.path as path

--- a/raytracing/graphics.py
+++ b/raytracing/graphics.py
@@ -1,4 +1,5 @@
 from raytracing.graphicComponents import *
+from .matrix import Lens, Space, Aperture
 from .specialtylenses import Objective
 from .matrixgroup import MatrixGroup
 import numpy as np
@@ -451,13 +452,13 @@ class ObjectiveGraphic(MatrixGroupGraphic):
 class GraphicOf:
     def __new__(cls, element, x=0.0, minSize=0) -> Union[MatrixGraphic, None, list]:
         instance = type(element).__name__
-        if type(element) is Objective or issubclass(type(element), Objective):
+        if issubclass(type(element), Objective):
             return ObjectiveGraphic(element, x=x)
-        if instance is 'Lens':
+        if issubclass(type(element), Lens):
             return LensGraphic(element, x=x, minSize=minSize)
-        if instance is 'Space':
+        if issubclass(type(element), Space):
             return None
-        if instance is 'Aperture':
+        if issubclass(type(element), Aperture):
             return ApertureGraphic(element, x=x)
         if element.surfaces:
             return SurfacesGraphic(element, x=x)

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1670,6 +1670,13 @@ class Space(Matrix):
         else:
             return self
 
+class ToConjugate(Space):
+    def __init__(self, element):
+        super(ToConjugate, self).__init__(d=element.forwardConjugate().d)
+
+class ToFocus(Space):
+    def __init__(self, element):
+        super(ToFocus, self).__init__(d=element.backFocalLength())
 
 class DielectricInterface(Matrix):
     """A dielectric interface of radius R, with an index n1 before and n2

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -204,6 +204,17 @@ class Matrix(object):
 
         return surfaces
     
+    def fromFocusToFocus(self):
+        """
+        A simple method to obtain a MatrixGroup that includes
+        all three matrices to travel from the front focus, through
+        the lens, and then to the back focus.
+        """
+        from .matrixgroup import MatrixGroup
+        return MatrixGroup([Space(self.frontFocalLength()), self, Space(self.backFocalLength())])
+
+
+
     def __mul__(self, rightSide):
         """Operator overloading allowing easy-to-read matrix multiplication
         with other `Matrix`, with a `Ray` or a `GaussianBeam`.
@@ -1462,6 +1473,7 @@ class Lens(Matrix):
                                    frontVertex=0,
                                    backVertex=0,
                                    label=label)
+        self.f = f
         self._physicalHalfHeight = 4  # FIXME: keep a minimum half height when infinite ?
 
     @property
@@ -1671,10 +1683,19 @@ class Space(Matrix):
             return self
 
 class ToConjugate(Space):
+    """ 
+    A method to obtain the Space() matrix that leads to the conjugate
+    plane assuming an object at the front of `element`.
+    """
+
     def __init__(self, element):
         super(ToConjugate, self).__init__(d=element.forwardConjugate().d)
 
 class ToFocus(Space):
+    """ 
+    A method to obtain the Space() matrix that leads to the back focal spot
+    of the `element`.
+    """
     def __init__(self, element):
         super(ToFocus, self).__init__(d=element.backFocalLength())
 

--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1684,12 +1684,18 @@ class Space(Matrix):
 
 class ToConjugate(Space):
     """ 
-    A method to obtain the Space() matrix that leads to the conjugate
+    A method to obtain the Space() matrix that leads to the forward conjugate
     plane assuming an object at the front of `element`.
+
+    It is possible the distance traveled is backwards, if the conjugate plane corresponds to a virtual image.
     """
 
     def __init__(self, element):
-        super(ToConjugate, self).__init__(d=element.forwardConjugate().d)
+        d = element.forwardConjugate().d
+        if isfinite(d):
+            super(ToConjugate, self).__init__(d=element.forwardConjugate().d)
+        else:
+            raise ValueError("The conjugate plane is at infinity, and Raytracing cannot handle matrix multiplications with infinity (we often get infinity * 0, which is undefined.")
 
 class ToFocus(Space):
     """ 
@@ -1697,7 +1703,11 @@ class ToFocus(Space):
     of the `element`.
     """
     def __init__(self, element):
-        super(ToFocus, self).__init__(d=element.backFocalLength())
+        bfl = element.backFocalLength()
+        if bfl is not None:
+            super(ToFocus, self).__init__(d=bfl)
+        else:
+            raise ValueError("The focal plane is at infinity, and Raytracing cannot handle matrix multiplications with infinity (we often get infinity * 0, which is undefined.")
 
 class DielectricInterface(Matrix):
     """A dielectric interface of radius R, with an index n1 before and n2

--- a/raytracing/preferences.py
+++ b/raytracing/preferences.py
@@ -26,6 +26,7 @@ class Preferences(dict):
             prefDir = "."
 
         self.path = os.path.join(prefDir, prefFilename)
+        self.readFromDisk()
 
     def update(self, *args, **kwargs):
         for k, v in dict(*args, **kwargs).items():

--- a/raytracing/preferences.py
+++ b/raytracing/preferences.py
@@ -1,5 +1,4 @@
 import os
-from os.path import expanduser
 import json
 import platform
 
@@ -12,13 +11,13 @@ class Preferences(dict):
 
         try:
             if platform.system() == 'Darwin':
-                home = expanduser("~")
+                home = os.path.expanduser("~")
                 prefDir = os.path.join(home, "Library","Preferences")
             elif platform.system() == 'Windows':
                 from win32com.shell import shell, shellcon
                 prefDir = shell.SHGetFolderPath(0, shellcon.CSIDL_APPDATA, None, 0)
             elif platform.system() == 'Linux':
-                home = expanduser("~")
+                home = os.path.expanduser("~")
                 prefDir = os.path.join(home, ".config")
                 if not os.path.exists(prefDir):
                     os.mkdir(prefDir)

--- a/raytracing/preferences.py
+++ b/raytracing/preferences.py
@@ -1,0 +1,44 @@
+import os
+from os.path import expanduser
+import json
+import platform
+
+class Preferences:
+    def __init__(self):
+        prefFilename = "ca.dcclab.python.raytracing.json"
+        if platform.system() == 'Darwin':
+            home = expanduser("~")
+            prefDir = os.path.join(home, "Library","Preferences")
+        elif platform.system() == 'Windows':
+            from win32com.shell import shell, shellcon
+            prefDir = shell.SHGetFolderPath(0, shellcon.CSIDL_APPDATA, None, 0)
+        elif platform.system() == 'Linux':
+            home = expanduser("~")
+            prefDir = os.path.join(home, ".config")
+            if not os.path.exists(prefDir):
+                os.mkdir(prefDir)
+        else:
+            prefDir = "."
+        
+        self.path = os.path.join(prefDir, prefFilename)
+        self.variables = self.readPreferences()
+
+    def resetPreferences(self):
+        os.remove(self.path)
+        self.writePreferences(dict())
+
+    def readPreferences(self):
+        if not os.path.exists(self.path):
+            self.writePreferences(dict())
+
+        with open(self.path, "r") as prefFile:
+            try:
+                data = json.load(prefFile)
+            except Exception as err:
+                data = dict()
+
+        return data
+
+    def writePreferences(self, preferencesData):
+        with open(self.path, "w+") as prefFile:
+            json.dump(preferencesData, prefFile)

--- a/raytracing/tests/testsMatrix.py
+++ b/raytracing/tests/testsMatrix.py
@@ -2,18 +2,10 @@ import envtest  # modifies path
 import subprocess
 
 from raytracing import *
-
 inf = float("+inf")
 
 
 class TestMatrix(envtest.RaytracingTestCase):
-    def testWarningsFormat(self):
-        message = "This is a test."
-        filename = "test.py"
-        lineno = 10
-        category = UserWarning
-        warningsMessage = warningLineFormat(message, category, filename, lineno)
-        self.assertEqual(warningsMessage, "\ntest.py: 10\nUserWarning: This is a test.\n")
 
     def testMatrix(self):
         m = Matrix()

--- a/raytracing/tests/testsMatrixSubclasses.py
+++ b/raytracing/tests/testsMatrixSubclasses.py
@@ -411,5 +411,42 @@ class TestAperture(envtest.RaytracingTestCase):
         self.assertIsNone(s.backVertex)
 
 
+class TestToConjugateToFocus(envtest.RaytracingTestCase):
+
+    def testToConjugateMatrix(self):
+        g = MatrixGroup([Space(d=10), Lens(f=5)])
+        m = ToConjugate(g)
+        self.assertEqual(m.B, 10.0)
+        self.assertTrue((m*g).isImaging)
+
+    def testToConjugateMatrixSpace(self):
+        m = ToConjugate(Space(d=10))
+        self.assertEqual(m.B, -10.0)
+        self.assertTrue(m.isImaging)
+
+    def testToInfiniteConjugateMatrixSpace(self):
+        path = ImagingPath()
+        path.append(Space(d=5))
+        path.append(Lens(f=5))
+        with self.assertRaises(ValueError):
+            path.append(ToConjugate(path))
+
+    def testToConjugateMatrixSpace(self):
+        self.assertEqual(ToConjugate(Lens(f=5)).B, 0.0)
+
+    def testToFocus(self):
+        self.assertEqual(ToFocus(Lens(f=5)).B, 5.0)
+
+    def testToFocusAtInf(self):
+        with self.assertRaises(ValueError):
+            self.assertEqual(ToFocus(Space(d=5)).B, 5.0)
+
+    def testFromFocusToFocus(self):
+        m = Lens(f=5).fromFocusToFocus()
+        self.assertEqual(m.A, 0)
+        self.assertEqual(m.B, 5)
+        self.assertEqual(m.C, -1/5)
+        self.assertEqual(m.D, 0)
+
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsPreferences.py
+++ b/raytracing/tests/testsPreferences.py
@@ -4,6 +4,15 @@ from raytracing.preferences import Preferences
 
 
 class TestPrefs(envtest.RaytracingTestCase):
+    def setUp(self):
+        super().setUp()
+        self.savedPrefs = Preferences()
+        self.savedPrefs.readFromDisk()
+
+    def tearDown(self):
+        self.savedPrefs.writeToDisk()
+        super().tearDown()
+
     def testInitPrefs(self):
         p = Preferences()
         self.assertIsNotNone(p)
@@ -54,6 +63,11 @@ class TestPrefs(envtest.RaytracingTestCase):
         p["test2"] = "ouch"
         p["test3"] = "ouch"
         self.assertTrue(len(p.keys()) >= 4)
+
+    def testVersionCheckPrefs(self):
+        p = Preferences()
+        self.assertIsNotNone(p)
+        self.assertTrue("lastVersionCheck" in p.keys())
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsPreferences.py
+++ b/raytracing/tests/testsPreferences.py
@@ -69,5 +69,19 @@ class TestPrefs(envtest.RaytracingTestCase):
         self.assertIsNotNone(p)
         self.assertTrue("lastVersionCheck" in p.keys())
 
+    def testSaveSilentMode(self):
+        silentMode(saveToPrefs=True)
+        p = Preferences()
+        self.assertIsNotNone(p)
+        self.assertTrue("mode" in p.keys())
+        self.assertEqual(p["mode"], "silent")
+
+    def testSaveExpertMode(self):
+        expertMode(saveToPrefs=True)
+        p = Preferences()
+        self.assertIsNotNone(p)
+        self.assertTrue("mode" in p.keys())
+        self.assertEqual(p["mode"], "expert")
+
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsPreferences.py
+++ b/raytracing/tests/testsPreferences.py
@@ -1,0 +1,38 @@
+import envtest # modifies path
+from raytracing import *
+from raytracing.preferences import Preferences
+
+
+class TestPrefs(envtest.RaytracingTestCase):
+    def testInitPrefs(self):
+        p = Preferences()
+        self.assertIsNotNone(p)
+
+    def testReset(self):
+        p = Preferences()
+        p.resetPreferences()
+        self.assertTrue(os.path.exists(p.path))
+        v = p.readPreferences()
+        self.assertFalse(v) # empty
+
+    def testPathExists(self):
+        p = Preferences()
+        self.assertIsNotNone(p.path)
+        self.assertTrue(os.path.exists(p.path))
+
+    def testReadPrefs(self):
+        p = Preferences()
+        d = p.readPreferences()
+        self.assertIsNotNone(d)
+        self.assertTrue(isinstance(d, dict))
+
+    def testWritePrefs(self):
+        p = Preferences()
+        d = p.readPreferences()
+        d["test"] = 123
+        p.writePreferences(d)
+        d2 = p.readPreferences()
+        self.assertTrue(d2["test"] == 123)
+
+if __name__ == '__main__':
+    envtest.main()

--- a/raytracing/tests/testsPreferences.py
+++ b/raytracing/tests/testsPreferences.py
@@ -1,5 +1,5 @@
 import envtest # modifies path
-from raytracing import *
+import os
 from raytracing.preferences import Preferences
 
 
@@ -63,41 +63,6 @@ class TestPrefs(envtest.RaytracingTestCase):
         p["test2"] = "ouch"
         p["test3"] = "ouch"
         self.assertTrue(len(p.keys()) >= 4)
-
-    def testVersionCheckPrefs(self):
-        p = Preferences()
-        self.assertIsNotNone(p)
-        self.assertTrue("lastVersionCheck" in p.keys())
-
-    def testSaveBeginnerMode(self):
-        beginnerMode(saveToPrefs=True)
-        p = Preferences()
-        self.assertIsNotNone(p)
-        self.assertTrue("mode" in p.keys())
-        self.assertEqual(p["mode"], "beginner")
-        expertMode(saveToPrefs=False)
-        silentMode(saveToPrefs=False)
-        self.assertEqual(p["mode"], "beginner")
-
-    def testSaveSilentMode(self):
-        silentMode(saveToPrefs=True)
-        p = Preferences()
-        self.assertIsNotNone(p)
-        self.assertTrue("mode" in p.keys())
-        self.assertEqual(p["mode"], "silent")
-        expertMode(saveToPrefs=False)
-        beginnerMode(saveToPrefs=False)
-        self.assertEqual(p["mode"], "silent")
-
-    def testSaveExpertMode(self):
-        expertMode(saveToPrefs=True)
-        p = Preferences()
-        self.assertIsNotNone(p)
-        self.assertTrue("mode" in p.keys())
-        self.assertEqual(p["mode"], "expert")
-        silentMode(saveToPrefs=False)
-        beginnerMode(saveToPrefs=False)
-        self.assertEqual(p["mode"], "expert")
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsPreferences.py
+++ b/raytracing/tests/testsPreferences.py
@@ -69,6 +69,16 @@ class TestPrefs(envtest.RaytracingTestCase):
         self.assertIsNotNone(p)
         self.assertTrue("lastVersionCheck" in p.keys())
 
+    def testSaveBeginnerMode(self):
+        beginnerMode(saveToPrefs=True)
+        p = Preferences()
+        self.assertIsNotNone(p)
+        self.assertTrue("mode" in p.keys())
+        self.assertEqual(p["mode"], "beginner")
+        expertMode(saveToPrefs=False)
+        silentMode(saveToPrefs=False)
+        self.assertEqual(p["mode"], "beginner")
+
     def testSaveSilentMode(self):
         silentMode(saveToPrefs=True)
         p = Preferences()
@@ -76,6 +86,7 @@ class TestPrefs(envtest.RaytracingTestCase):
         self.assertTrue("mode" in p.keys())
         self.assertEqual(p["mode"], "silent")
         expertMode(saveToPrefs=False)
+        beginnerMode(saveToPrefs=False)
         self.assertEqual(p["mode"], "silent")
 
     def testSaveExpertMode(self):
@@ -85,6 +96,7 @@ class TestPrefs(envtest.RaytracingTestCase):
         self.assertTrue("mode" in p.keys())
         self.assertEqual(p["mode"], "expert")
         silentMode(saveToPrefs=False)
+        beginnerMode(saveToPrefs=False)
         self.assertEqual(p["mode"], "expert")
 
 if __name__ == '__main__':

--- a/raytracing/tests/testsPreferences.py
+++ b/raytracing/tests/testsPreferences.py
@@ -12,8 +12,7 @@ class TestPrefs(envtest.RaytracingTestCase):
         p = Preferences()
         p.resetPreferences()
         self.assertTrue(os.path.exists(p.path))
-        v = p.readPreferences()
-        self.assertFalse(v) # empty
+        self.assertFalse(p.keys()) # empty
 
     def testPathExists(self):
         p = Preferences()
@@ -22,17 +21,39 @@ class TestPrefs(envtest.RaytracingTestCase):
 
     def testReadPrefs(self):
         p = Preferences()
-        d = p.readPreferences()
-        self.assertIsNotNone(d)
-        self.assertTrue(isinstance(d, dict))
+        p.readFromDisk()
+        self.assertIsNotNone(p)
 
     def testWritePrefs(self):
         p = Preferences()
-        d = p.readPreferences()
-        d["test"] = 123
-        p.writePreferences(d)
-        d2 = p.readPreferences()
-        self.assertTrue(d2["test"] == 123)
+        p["test"] = 123
+        p.writeToDisk()
+        p.readFromDisk()
+        self.assertTrue(p["test"] == 123)
+
+    def testPrefsAsDict(self):
+        p = Preferences()
+        p["test"] = 345
+        self.assertEqual(p["test"], 345)        
+
+    # def testPrefsAsIter(self):
+    #     p = Preferences()
+    #     p["test"] = 1
+    #     for key in p:
+    #         self.assertEqual(key, "test")
+
+    def testZZPrefsIncludesKey(self):
+        p = Preferences()
+        p["test"] = "ouch"
+        self.assertTrue('test' in p)
+
+    def testZZZPrefsLargeDict(self):
+        p = Preferences()
+        p["test"] = "ouch"
+        p["test1"] = "ouch"
+        p["test2"] = "ouch"
+        p["test3"] = "ouch"
+        self.assertTrue(len(p.keys()) >= 4)
 
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsPreferences.py
+++ b/raytracing/tests/testsPreferences.py
@@ -75,12 +75,16 @@ class TestPrefs(envtest.RaytracingTestCase):
         self.assertIsNotNone(p)
         self.assertTrue("mode" in p.keys())
         self.assertEqual(p["mode"], "silent")
+        expertMode(saveToPrefs=False)
+        self.assertEqual(p["mode"], "silent")
 
     def testSaveExpertMode(self):
         expertMode(saveToPrefs=True)
         p = Preferences()
         self.assertIsNotNone(p)
         self.assertTrue("mode" in p.keys())
+        self.assertEqual(p["mode"], "expert")
+        silentMode(saveToPrefs=False)
         self.assertEqual(p["mode"], "expert")
 
 if __name__ == '__main__':

--- a/raytracing/tests/testsPreferencesRaytracing.py
+++ b/raytracing/tests/testsPreferencesRaytracing.py
@@ -47,5 +47,14 @@ class TestRaytracingPrefs(envtest.RaytracingTestCase):
         beginnerMode(saveToPrefs=False)
         self.assertEqual(p["mode"], "expert")
 
+    def testWarningsFormat(self):
+        beginnerMode()
+        message = "This is a test."
+        filename = "test.py"
+        lineno = 10
+        category = UserWarning
+        warningsMessage = warningLineFormat(message, category, filename, lineno)
+        self.assertEqual(warningsMessage, "UserWarning: This is a test.\n")
+
 if __name__ == '__main__':
     envtest.main()

--- a/raytracing/tests/testsPreferencesRaytracing.py
+++ b/raytracing/tests/testsPreferencesRaytracing.py
@@ -1,0 +1,51 @@
+import envtest # modifies path
+from raytracing import *
+from raytracing.preferences import Preferences
+
+class TestRaytracingPrefs(envtest.RaytracingTestCase):
+    def setUp(self):
+        super().setUp()
+        self.savedPrefs = Preferences()
+        self.savedPrefs.readFromDisk()
+
+    def tearDown(self):
+        self.savedPrefs.writeToDisk()
+        super().tearDown()
+
+    def testVersionCheckPrefs(self):
+        p = Preferences()
+        self.assertIsNotNone(p)
+        self.assertTrue("lastVersionCheck" in p.keys())
+
+    def testSaveBeginnerMode(self):
+        beginnerMode(saveToPrefs=True)
+        p = Preferences()
+        self.assertIsNotNone(p)
+        self.assertTrue("mode" in p.keys())
+        self.assertEqual(p["mode"], "beginner")
+        expertMode(saveToPrefs=False)
+        silentMode(saveToPrefs=False)
+        self.assertEqual(p["mode"], "beginner")
+
+    def testSaveSilentMode(self):
+        silentMode(saveToPrefs=True)
+        p = Preferences()
+        self.assertIsNotNone(p)
+        self.assertTrue("mode" in p.keys())
+        self.assertEqual(p["mode"], "silent")
+        expertMode(saveToPrefs=False)
+        beginnerMode(saveToPrefs=False)
+        self.assertEqual(p["mode"], "silent")
+
+    def testSaveExpertMode(self):
+        expertMode(saveToPrefs=True)
+        p = Preferences()
+        self.assertIsNotNone(p)
+        self.assertTrue("mode" in p.keys())
+        self.assertEqual(p["mode"], "expert")
+        silentMode(saveToPrefs=False)
+        beginnerMode(saveToPrefs=False)
+        self.assertEqual(p["mode"], "expert")
+
+if __name__ == '__main__':
+    envtest.main()

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -29,7 +29,6 @@ def beginnerMode(saveToPrefs=False):
         prefs["mode"] = "beginner"
 
 def expertMode(saveToPrefs=False):
-    print("Expert mode ON")
     warnings.formatwarning = warningLineFormat
     warnings.filterwarnings("ignore", category=BeginnerHint)
     warnings.filterwarnings("once", category=ExpertNote)

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -2,6 +2,7 @@ import math
 import warnings
 import inspect
 import sys
+from .preferences import Preferences
 
 """ Two constants: deg and rad to quickly convert to degrees
 or radians with angle*degPerRad or angle*radPerDeg """
@@ -18,26 +19,34 @@ class ExpertNote(UserWarning):
 def warningLineFormat(message, category, filename, lineno, line=None):
     return '{2}: {3}\n'.format(filename, lineno, category.__name__, message)
 
-def beginnerMode():
+def beginnerMode(saveToPrefs=False):
     warnings.formatwarning = warningLineFormat
     warnings.filterwarnings("always", category=BeginnerHint)
     warnings.filterwarnings("default", category=ExpertNote)
     warnings.filterwarnings("default", category=DeprecationWarning)
+    if saveToPrefs:
+        prefs = Preferences()
+        prefs["mode"] = "beginner"
 
-def expertMode():
+def expertMode(saveToPrefs=False):
     print("Expert mode ON")
     warnings.formatwarning = warningLineFormat
     warnings.filterwarnings("ignore", category=BeginnerHint)
     warnings.filterwarnings("once", category=ExpertNote)
     warnings.filterwarnings("once", category=DeprecationWarning)
+    if saveToPrefs:
+        prefs = Preferences()
+        prefs["mode"] = "expert"
 
-
-def silentMode():
+def silentMode(saveToPrefs=False):
     warnings.formatwarning = warningLineFormat
     warnings.filterwarnings("ignore", category=BeginnerHint)
     warnings.filterwarnings("ignore", category=ExpertNote)
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     warnings.filterwarnings("ignore", category=UserWarning)
+    if saveToPrefs:
+        prefs = Preferences()
+        prefs["mode"] = "silent"
     
 def isAlmostZero(value, epsilon=1e-3):
     return abs(value) < epsilon

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -16,7 +16,7 @@ class ExpertNote(UserWarning):
     pass
 
 def warningLineFormat(message, category, filename, lineno, line=None):
-    return '\n{0}: {1}\n{2}: {3}\n'.format(filename, lineno, category.__name__, message)
+    return '{2}: {3}\n'.format(filename, lineno, category.__name__, message)
 
 def beginnerMode():
     warnings.formatwarning = warningLineFormat
@@ -32,6 +32,13 @@ def expertMode():
     warnings.filterwarnings("once", category=DeprecationWarning)
 
 
+def silentMode():
+    warnings.formatwarning = warningLineFormat
+    warnings.filterwarnings("ignore", category=BeginnerHint)
+    warnings.filterwarnings("ignore", category=ExpertNote)
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=UserWarning)
+    
 def isAlmostZero(value, epsilon=1e-3):
     return abs(value) < epsilon
 

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -24,6 +24,7 @@ def beginnerMode(saveToPrefs=False):
     warnings.filterwarnings("always", category=BeginnerHint)
     warnings.filterwarnings("default", category=ExpertNote)
     warnings.filterwarnings("default", category=DeprecationWarning)
+    warnings.filterwarnings("default", category=UserWarning)
     if saveToPrefs:
         prefs = Preferences()
         prefs["mode"] = "beginner"
@@ -33,6 +34,7 @@ def expertMode(saveToPrefs=False):
     warnings.filterwarnings("ignore", category=BeginnerHint)
     warnings.filterwarnings("once", category=ExpertNote)
     warnings.filterwarnings("once", category=DeprecationWarning)
+    warnings.filterwarnings("once", category=UserWarning)
     if saveToPrefs:
         prefs = Preferences()
         prefs["mode"] = "expert"

--- a/raytracing/utils.py
+++ b/raytracing/utils.py
@@ -10,6 +10,7 @@ or radians with angle*degPerRad or angle*radPerDeg """
 degPerRad = 180.0 / math.pi
 radPerDeg = math.pi / 180.0
 
+
 class BeginnerHint(UserWarning):
     pass
 
@@ -20,6 +21,17 @@ def warningLineFormat(message, category, filename, lineno, line=None):
     return '{2}: {3}\n'.format(filename, lineno, category.__name__, message)
 
 def beginnerMode(saveToPrefs=False):
+    """
+    Simple function to set Raytracing into beginner mode. It will print warnings when it suspects you
+    are making a mistake or are not using the module properly.
+
+    Parameters
+    ----------
+    saveToPrefs : Bool
+        If True, this will be saved to the Preferences and retained for next time.
+
+    """
+
     warnings.formatwarning = warningLineFormat
     warnings.filterwarnings("always", category=BeginnerHint)
     warnings.filterwarnings("default", category=ExpertNote)
@@ -30,6 +42,15 @@ def beginnerMode(saveToPrefs=False):
         prefs["mode"] = "beginner"
 
 def expertMode(saveToPrefs=False):
+    """
+    Simple function to set Raytracing into expert mode: very little warnings printed to screen.
+
+    Parameters
+    ----------
+    saveToPrefs : Bool
+        If True, this will be saved to the Preferences and retained for next time.
+
+    """
     warnings.formatwarning = warningLineFormat
     warnings.filterwarnings("ignore", category=BeginnerHint)
     warnings.filterwarnings("once", category=ExpertNote)
@@ -40,6 +61,15 @@ def expertMode(saveToPrefs=False):
         prefs["mode"] = "expert"
 
 def silentMode(saveToPrefs=False):
+    """
+    Simple function to set Raytracing into silent mode: no warnings printed to screen
+
+    Parameters
+    ----------
+    saveToPrefs : Bool
+        If True, this will be saved to the Preferences and retained for next time.
+
+    """
     warnings.formatwarning = warningLineFormat
     warnings.filterwarnings("ignore", category=BeginnerHint)
     warnings.filterwarnings("ignore", category=ExpertNote)
@@ -50,18 +80,82 @@ def silentMode(saveToPrefs=False):
         prefs["mode"] = "silent"
     
 def isAlmostZero(value, epsilon=1e-3):
+    """
+    Convenience function for readability: checks if a number is almost zero by comparing to epsilon.
+
+    Parameters
+    ----------
+    value : float
+        If value is less than epsilon, returns True.
+
+    Returns
+    -------
+    bool
+        If the value is almost zero, returns True
+
+    """
     return abs(value) < epsilon
 
 
 def isNotZero(value, epsilon=1e-3):
+    """
+    Convenience function for readability: checks if a number is not zero by comparing to epsilon.
+
+    Parameters
+    ----------
+    value : float
+        If value is more than epsilon, returns True.
+
+    Returns
+    -------
+    bool
+        If the value is not zero, returns True
+
+    """
     return abs(value) > epsilon
 
 
 def areAbsolutelyAlmostEqual(left, right, epsilon=1e-3):
+    """
+    Convenience function for readability: checks if a two numbers are almost equal by comparing their difference to epsilon.
+
+    Parameters
+    ----------
+    left : float
+        A value
+
+    right : float
+        Another value
+
+    Returns
+    -------
+    bool
+        If the difference between the two values is almost zero, returns True
+
+    """
+
     return abs(left - right) < epsilon
 
 
 def areRelativelyAlmostEqual(left, right, epsilon=1e-3):
+    """
+    Convenience function for readability: checks if a two numbers are almost equal in relative terms (epsilon is a percentage).
+    Does not work when one value is zero.
+
+    Parameters
+    ----------
+    left : float
+        A value
+
+    right : float
+        Another value
+
+    Returns
+    -------
+    bool
+        If the difference between the two values is almost zero, returns True
+
+    """
     absDiff = abs(left - right)
     relTol1 = absDiff / abs(left)
     relTol2 = absDiff / abs(right)
@@ -88,6 +182,20 @@ def deprecated(reason: str):
     return deprecatedFunc
 
 def allSubclasses(aClass):
+    """
+    A function to obtain all the subclasses of a given class
+
+    Parameters
+    ----------
+
+    aClass : any class
+
+    Returns
+    -------
+
+    A list of classes that are subclasses
+     """
+
     subc = []
     for child in aClass.__subclasses__():
         if len(child.__subclasses__()) == 0:
@@ -118,3 +226,27 @@ def warnDeprecatedObjectReferences():
     warnings.warn("Object references (fanAngle, fanNumber, rayNumber) will be removed from ImagingPath in future "
                   "versions. Create an ObjectRays(...) instead and provide it to the display "
                   "with ImagingPath.display(rays=...)", category=DeprecationWarning)
+
+def checkLatestVersion():
+    """
+    Warns the user on screen that a new version exists if the current version is older than the version on PyPi
+
+    """
+    try:
+        import json
+        import urllib.request
+        from packaging.version import Version
+
+        url = "https://pypi.org/pypi/raytracing/json"
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, timeout=1) as response:
+            data = json.load(response)
+            versions = [ Version(version) for version in data["releases"].keys() ]
+            latestVersion = versions[-1]
+            if Version(__version__) < latestVersion:
+                print("Latest version {0} available on PyPi (you are using {1}).".format(latestVersion, __version__))
+                print("run `pip install --upgrade raytracing` to update.")
+
+    except Exception as err:
+        print("Unable to check for latest version of raytracing on pypi.org")
+        print(err)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ rm dist/*; python3 setup.py sdist bdist_wheel; python3 -m twine upload dist/*
 
 setuptools.setup(
     name="raytracing",
-    version="1.3.8",
+    version="1.3.9",
     url="https://github.com/DCC-Lab/RayTracing",
     author="Daniel Cote",
     author_email="dccote@cervo.ulaval.ca",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ rm dist/*; python3 setup.py sdist bdist_wheel; python3 -m twine upload dist/*
 
 setuptools.setup(
     name="raytracing",
-    version="1.3.7",
+    version="1.3.8",
     url="https://github.com/DCC-Lab/RayTracing",
     author="Daniel Cote",
     author_email="dccote@cervo.ulaval.ca",


### PR DESCRIPTION
Contrary to what the name of the branch appears to say, I did not fix the Olympus back focal length yet.

Created a simple `Preferences` class to store last version check and a "mode": expert, silent and beginner to restrict the warnings a bit more. They get annoying when you know what you are doing. It may be used for other things in the future.  It saves a text file with the preferences in the "appropriate" directory for macOS, Windows and Linux.

Version check is actually better and working properly now.

Added a few convenience functions: 
* `toConjugate(element)` that will return a `Space` matrix that will stop at the conjugate assuming an image at the front of element (a finite conjugate at the front of the element). `element` can be a `MatrixGroup`.
   * It could be negative, in which case the image is virtual.
   * The matrix returned is necessarily an imaging matrix `toConjugate(element).isImaging == True`
* `toFocus(element)` that will return a `Space` matrix that will stop at the focus of the element. Again, `element` can be a `MatrixGroup`.
* `focusToFocus(element)` will return a MatrixGroup with `[Space(d=element.frontFocalLength), element, Space(d=element.backFocalLength)]`, essentially traveling from one focus to the other.

It also means you can do this:
```
path = ImagingPath()
path.append(Space(d=40))
path.append(Lens(f=13))
path.append(ToConjugate(path)) # This goes straight to the image
```

