### PR TITLE
Fixed display bug

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -146,6 +146,9 @@ class Figure:
                       useDataUnits=False, alignment='left')
         self.labels.append(label)
 
+    def resetDisplay(self):
+        return
+
     def setPrincipalAndAxialRays(self):
         (stopPosition, stopDiameter) = self.path.apertureStop()
         if stopPosition is None:

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -110,7 +110,7 @@ class Figure:
     def fontScale(self):
         return self.designParams['fontScale']
 
-    def initializeDisplay(self):
+    def applyDesign(self):
         """ Configure the imaging path and the figure according to the display conditions. """
 
         note1 = ""
@@ -145,9 +145,6 @@ class Figure:
         label = Label(x=0.05, y=0.02, text=note1, fontsize=12*self.fontScale,
                       useDataUnits=False, alignment='left')
         self.labels.append(label)
-
-    def resetDisplay(self):
-        return
 
     def setPrincipalAndAxialRays(self):
         (stopPosition, stopDiameter) = self.path.apertureStop()

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -991,7 +991,8 @@ class ImagingPath(MatrixGroup):
                                   'Using default ObjectRays.', category=BeginnerHint)
 
         if 'ObjectRays' not in [type(rays).__name__ for rays in raysList]:
-            if self.fanAngle is None:
+            fanAngle = self.fanAngle
+            if fanAngle is None:
                 fanAngle = np.tan(self.figure.displayRange / 2 / self.L / 5)
             defaultObject = ObjectRays(self.objectHeight, z=self.objectPosition,
                                        halfAngle=fanAngle, T=self.rayNumber, H=self.fanNumber)
@@ -1001,6 +1002,10 @@ class ImagingPath(MatrixGroup):
 
         self.figure.display(raysList=raysList, comments=comments, title=self.label,
                             backend='matplotlib', display3D=False, interactive=interactive, filepath=filePath)
+
+        oldDesign = self.figure.design
+        self.figure = Figure(opticalPath=self)
+        self.design = oldDesign
 
     def saveFigure(self, filePath, rays=None, raysList=None, removeBlocked=True, comments=None,
                    onlyPrincipalAndAxialRays=None, limitObjectToFieldOfView=None):

--- a/raytracing/imagingpath.py
+++ b/raytracing/imagingpath.py
@@ -977,7 +977,7 @@ class ImagingPath(MatrixGroup):
         if rays is not None:
             raysList.append(rays)
 
-        self.figure.initializeDisplay()
+        self.figure.applyDesign()
 
         if len(raysList) == 0:
             self.figure.designParams['showFOV'] = True
@@ -1003,9 +1003,9 @@ class ImagingPath(MatrixGroup):
         self.figure.display(raysList=raysList, comments=comments, title=self.label,
                             backend='matplotlib', display3D=False, interactive=interactive, filepath=filePath)
 
-        oldDesign = self.figure.design
+        savedDesignParams = self.figure.designParams
         self.figure = Figure(opticalPath=self)
-        self.design = oldDesign
+        self.design = savedDesignParams
 
     def saveFigure(self, filePath, rays=None, raysList=None, removeBlocked=True, comments=None,
                    onlyPrincipalAndAxialRays=None, limitObjectToFieldOfView=None):


### PR DESCRIPTION
We could not `display` a path twice.  I had to reset the figure because it was still keeping the lines and patches from the previous.  I decided not to save anything, just recreate.