### PR TITLE
Minor fix to keep python 3.6 support

### DIFF
--- a/raytracing/__init__.py
+++ b/raytracing/__init__.py
@@ -71,7 +71,8 @@ import tempfile
 
 def lastCheckMoreThanADay():
     if "lastVersionCheck" in prefs:
-        then = datetime.fromisoformat(prefs["lastVersionCheck"])
+        isoFormat = "%Y-%m-%dT%H:%M:%S.%f"
+        then = datetime.strptime(prefs["lastVersionCheck"], isoFormat)
         difference = datetime.now() - then
         if difference.days > 1:
             return True


### PR DESCRIPTION
Update __init__: remove datetime.fromisoformat() which requires python 3.7+

With respect to setup.py: `python_requires='>=3.6'`.