### PR TITLE
Invert display radius of CurvedMirror

### DIFF
--- a/raytracing/matrix.py
+++ b/raytracing/matrix.py
@@ -1582,7 +1582,7 @@ class CurvedMirror(Matrix):
     def forwardSurfaces(self):
         """ A list of surfaces that represents the element for drawing purposes 
         """
-        return [SphericalInterface(R=2/self.C)]
+        return [SphericalInterface(R=-2/self.C)]
 
     def pointsOfInterest(self, z):
         """ List of points of interest for this element as a dictionary:


### PR DESCRIPTION
Addressing  #465 

By default, when propagating from left to right, a positive surface radius means the focal point is on its right side. To inverse this behavior for CurvedMirror, we can change how the display components are initialized inside `forwardSurfaces` and negate the input radius.


```python
from raytracing import *

R = -100
L = 20
path = LaserCavity()
path.append(CurvedMirror(R=R, diameter=25))
path.append(Space(d=L))
path.append(CurvedMirror(R=R, diameter=25))
path.append(Space(d=L))
path.display()
```

![image](https://user-images.githubusercontent.com/29587649/226396133-5f110f83-1919-485e-a2d8-2ca8442c6d4a.png)
