### PR TITLE
`MplFigure.initVisibilityCheckBoxes` update for mpl3.9 compatibility

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -700,6 +700,7 @@ class MplFigure(Figure):
                 artist.set_transform(self.axes.transAxes)
             self.axes.add_artist(artist)
 
+#TODO: modify here since checkBoxes lines and rectangles attributes are deprecated
     def initVisibilityCheckBoxes(self):
         visibility = self.visibility
         if kElementsKey in visibility.keys():

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -704,24 +704,18 @@ class MplFigure(Figure):
         visibility = self.visibility
         if kElementsKey in visibility.keys():
             visibility.pop(kElementsKey)
-            
-        step = 0.15
-        num_keys = len(visibility.keys())
-        offset_fram_y = 0.85 - step*np.arange(num_keys)
-        offset_fram = [(0.1, float(i)) for i in offset_fram_y]
-        offset_label = [(0.25, float(i)-0.01) for i in offset_fram_y]
-        fontsize = [11]*num_keys
-        
-        subAxes = plt.axes([0.81, 0.4, 0.1, 0.5], frameon=False, anchor='NW')
-        self.checkBoxes = CheckButtons(subAxes, 
-                                       visibility.keys(), 
-                                       visibility.values())
-        self.checkBoxes.set_check_props({'offsets': offset_fram, 
-                                         's':100})
-        self.checkBoxes.set_frame_props({'offsets': offset_fram, 
-                                         's':100})
-        self.checkBoxes.set_label_props({'position': offset_label,
-                                          'fontsize': fontsize})
+
+        subAxes = plt.axes((0.81, 0.4, 0.1, 0.5), frameon=False, anchor='NW')
+
+        nBoxes = len(visibility)
+        heightStep = 0.15
+        offsets = [(0.11, 0.85 - heightStep * i) for i in range(nBoxes)]
+        checkProps = {'sizes': [100] * nBoxes, 'offsets': offsets}
+        self.checkBoxes = CheckButtons(
+            subAxes, visibility.keys(), visibility.values(), check_props=checkProps, frame_props=checkProps
+        )
+        self.checkBoxes.set_label_props({'x': [0.22] * nBoxes, 'y': [v[1] - 0.003 for v in offsets], 'fontsize': [11] * nBoxes})
+
         self.checkBoxes.on_clicked(self.onCheckBoxCallback)
 
     def updateGraphics(self):

--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -700,33 +700,28 @@ class MplFigure(Figure):
                 artist.set_transform(self.axes.transAxes)
             self.axes.add_artist(artist)
 
-#TODO: modify here since checkBoxes lines and rectangles attributes are deprecated
     def initVisibilityCheckBoxes(self):
         visibility = self.visibility
         if kElementsKey in visibility.keys():
             visibility.pop(kElementsKey)
-
-        subAxes = plt.axes([0.81, 0.4, 0.1, 0.5], frameon=False, anchor='NW')
-        self.checkBoxes = CheckButtons(subAxes, visibility.keys(), visibility.values())
-
+            
         step = 0.15
-        for i, (label, rectangle, lines) in enumerate(zip(self.checkBoxes.labels,
-                                                          self.checkBoxes.rectangles,
-                                                          self.checkBoxes.lines)):
-            h = 0.85 - step * i
-            label.set_fontsize(11)
-            rectangle.set_x(0.05)
-            rectangle.set_y(h)
-            rectangle.set(width=0.12, height=0.04)
-            label.set_y(h + 0.02)
-            label.set_x(0.2)
-
-            lineA, lineB = lines
-            lineA.set_xdata([0.05, 0.17])
-            lineB.set_xdata([0.05, 0.17])
-            lineA.set_ydata([h, h + 0.04])
-            lineB.set_ydata([h + 0.04, h])
-
+        num_keys = len(visibility.keys())
+        offset_fram_y = 0.85 - step*np.arange(num_keys)
+        offset_fram = [(0.1, float(i)) for i in offset_fram_y]
+        offset_label = [(0.25, float(i)-0.01) for i in offset_fram_y]
+        fontsize = [11]*num_keys
+        
+        subAxes = plt.axes([0.81, 0.4, 0.1, 0.5], frameon=False, anchor='NW')
+        self.checkBoxes = CheckButtons(subAxes, 
+                                       visibility.keys(), 
+                                       visibility.values())
+        self.checkBoxes.set_check_props({'offsets': offset_fram, 
+                                         's':100})
+        self.checkBoxes.set_frame_props({'offsets': offset_fram, 
+                                         's':100})
+        self.checkBoxes.set_label_props({'position': offset_label,
+                                          'fontsize': fontsize})
         self.checkBoxes.on_clicked(self.onCheckBoxCallback)
 
     def updateGraphics(self):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     keywords='optics optical lens ray tracing matrix matrices aperture field stop\
     monte carlo design raytracing zemax chromatic aberrations',
     packages=setuptools.find_packages(),
-    install_requires=['matplotlib>=3', 'numpy','pygments'],
+    install_requires=['matplotlib>=3.7', 'numpy','pygments'],
     python_requires='>=3.6',
     package_data = {
         # If any package contains *.txt or *.rst files, include them:


### PR DESCRIPTION
Dear all, 
today I had this same issue #474.
I then tried to update the method `MplFigure.initVisibilityCheckBoxes` to complain Matplotlib3.9 `CheckButtons`.
I have a reasonable behavior (tested on examples 1,2 and 7, but I don't understand  why for example 15 something strange is happening (no checkmark for the first key).

![Screenshot from 2024-08-03 01-35-18](https://github.com/user-attachments/assets/47e08179-7bb6-4420-a605-12dcbbcfd468)
![Screenshot from 2024-08-03 01-35-29](https://github.com/user-attachments/assets/2bb2a658-3e53-418e-9c9d-449fa6ea7004)

Any idea?