### PR TITLE
Fix figure drawn twice

### DIFF
--- a/raytracing/figure.py
+++ b/raytracing/figure.py
@@ -686,7 +686,7 @@ class MplFigure(Figure):
         for point in self.points:
             if point.hasPointMarker:
                 y = 0 if point.fixToAxis else point.y
-                self.axes.plot([point.x], [y], 'ko', markersize=3, color=point.color, linewidth=0.4)
+                self.axes.plot([point.x], [y], marker='o', markersize=5, color=point.color, linewidth=0.4)
             if point.text is not None:
                 point.fontsize *= self.fontScale
                 self.labels.append(point)

--- a/raytracing/graphics.py
+++ b/raytracing/graphics.py
@@ -233,11 +233,6 @@ class MatrixGraphic(Graphic):
                                  hasMarker=False))
 
     def display(self):
-        fig = self.drawFigure()
-        fig.display2D(interactive=False)
-        return fig
-
-    def drawFigure(self, figure = None) -> 'Figure':
         """ Display this component, without any ray tracing but with
         all of its cardinal points and planes.
 
@@ -260,6 +255,11 @@ class MatrixGraphic(Graphic):
         -----
         If the component has no power (i.e. C == 0) this will fail.
         """
+        fig = self.createFigure()
+        fig.display2D(interactive=False)
+        return fig
+
+    def createFigure(self) -> 'Figure':
         self.points = []
         self.points.extend(self.cardinalPoints)
         if self.matrix.L != 0:
@@ -272,14 +272,11 @@ class MatrixGraphic(Graphic):
         from .imagingpath import ImagingPath
         path = ImagingPath(elements=[self.matrix])
         mplFigure = MplFigure(path)
-        if figure is not None:
-            mplFigure.figure = figure
         mplFigure.graphicGroups['Elements'] = [self]
         if self.displayComponents:
             path.elements = self.matrix
             mplFigure.setGraphicsFromOpticalPath()
         mplFigure.create(title="Element properties")
-        mplFigure.draw()
         return mplFigure
 
 

--- a/raytracing/lensViewer.py
+++ b/raytracing/lensViewer.py
@@ -210,10 +210,11 @@ class OpticalComponentViewer(ViewerApp):
     def selection_changed(self):
         lens_label = self.menu.menu_items[self.menu.selected_index]
         lens = self.lenses[lens_label]
-        plot = self.figure.add_subplot()
 
         graphic = GraphicOf(lens)
-        self.figure = graphic.drawFigure().figure
+        graphic_figure = graphic.createFigure()
+        graphic_figure.draw()
+        self.figure = graphic_figure.figure
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bug introduced in dd840f70ec73636576f25b82273b8f83389c43ae due to a custom `drawFigure` endpoint for the LensViewer, while the main display2D was already in charge of drawing the figure. 

I renamed the custom endpoint `createFigure` and moved the required draw call on the client side (lensViewer).

Fixes #477 