### PR TITLE
Bundle the GUI as a standalone app via PyInstaller

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,0 +1,88 @@
+name: Build standalone app
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            artifact: Raytracing-macOS-arm64
+          - os: windows-latest
+            artifact: Raytracing-Windows
+          - os: ubuntu-22.04
+            artifact: Raytracing-Linux
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools_scm needs full history + tags
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Tk (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y python3-tk
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[gui]"
+          pip install pyperclip pillow pyinstaller
+
+      - name: Build with PyInstaller
+        run: pyinstaller --windowed --name Raytracing --noconfirm
+             --distpath packaging/dist --workpath packaging/build
+             raytracing/ui/raytracing_app.py
+
+      - name: Package macOS .app as zip
+        if: runner.os == 'macOS'
+        working-directory: packaging/dist
+        run: ditto -c -k --keepParent Raytracing.app Raytracing-macOS.zip
+
+      - name: Package Windows folder as zip
+        if: runner.os == 'Windows'
+        working-directory: packaging/dist
+        run: Compress-Archive -Path Raytracing -DestinationPath Raytracing-Windows.zip
+
+      - name: Package Linux folder as tar.gz
+        if: runner.os == 'Linux'
+        working-directory: packaging/dist
+        run: tar -czf Raytracing-Linux.tar.gz Raytracing
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            packaging/dist/Raytracing-macOS.zip
+            packaging/dist/Raytracing-Windows.zip
+            packaging/dist/Raytracing-Linux.tar.gz
+          if-no-files-found: ignore
+
+  release:
+    name: Attach to GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          fail_on_unmatched_files: false

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,8 @@ fabric.properties
 env-*/
 venv/
 raytracing/_version.py
+
+# PyInstaller build outputs (see packaging/BUILD.md)
+packaging/build/
+packaging/dist/
+build-app/

--- a/packaging/BUILD.md
+++ b/packaging/BUILD.md
@@ -83,6 +83,31 @@ consider `--icon app.ico` to set the executable icon. For a proper
 installer, wrap the `dist/Raytracing` folder with
 [Inno Setup](https://jrsoftware.org/isinfo.php) or NSIS.
 
+## Automated builds for all three platforms
+
+`.github/workflows/build-app.yml` builds macOS, Windows, and Linux
+bundles on GitHub Actions. Two triggers:
+
+- **Push a `v*` tag** — builds all three, attaches the zips/tarball to
+  the GitHub Release for that tag.
+- **Actions → "Build standalone app" → "Run workflow"** — manual
+  trigger, downloads available under the run's Artifacts section.
+
+Artifacts produced:
+
+- `Raytracing-macOS.zip` — contains `Raytracing.app` (Apple Silicon).
+  Built on `macos-14`; for Intel Macs, change the matrix entry to
+  `macos-13` or add both.
+- `Raytracing-Windows.zip` — contains a `Raytracing/` folder with
+  `Raytracing.exe` plus its DLLs.
+- `Raytracing-Linux.tar.gz` — contains a `Raytracing/` folder with the
+  executable, built against Ubuntu 22.04's glibc.
+
+The workflow installs Tk on Linux (`python3-tk`), runs the same
+PyInstaller command shown above, and does no code signing. Unsigned
+macOS builds will still prompt Gatekeeper; see the signing section
+above if you need a signed distribution.
+
 ## Alternative: install from PyPI
 
 For technical users, the simplest "deployment" is still:

--- a/packaging/BUILD.md
+++ b/packaging/BUILD.md
@@ -1,0 +1,97 @@
+# Building a standalone Raytracing app
+
+The GUI launched by `python -m raytracing -a` can be bundled into a
+double-clickable application so end users don't need to install Python
+or any dependencies. This is done with
+[PyInstaller](https://pyinstaller.org/).
+
+## One-time setup
+
+From the repo root, in the project's virtual environment:
+
+```bash
+pip install pyinstaller
+```
+
+Make sure the runtime dependencies are also installed in the same
+environment, since PyInstaller freezes whatever is importable there:
+
+```bash
+pip install -e .        # raytracing itself
+pip install mytk pyperclip pillow
+```
+
+## Build
+
+From the repo root:
+
+```bash
+pyinstaller --windowed --name Raytracing --noconfirm \
+    --distpath packaging/dist --workpath packaging/build \
+    raytracing/ui/raytracing_app.py
+```
+
+The result lands in `packaging/dist/`:
+
+- **macOS**: `Raytracing.app` — a standard `.app` bundle. Double-click
+  to launch, drag into `/Applications` to install.
+- **Windows**: `Raytracing/Raytracing.exe` inside a folder with all
+  DLLs. Zip the folder for distribution.
+- **Linux**: `Raytracing/Raytracing` binary inside a folder. Users run
+  the binary directly.
+
+Typical build time: ~1 minute. Typical bundle size: ~270 MB (numpy,
+matplotlib, and scipy dominate).
+
+## Flags explained
+
+- `--windowed` — on macOS/Windows, suppresses the terminal console
+  window that would otherwise open alongside the GUI.
+- `--name Raytracing` — sets the app/executable name.
+- `--noconfirm` — overwrites a previous build without prompting.
+- `--distpath` / `--workpath` — keeps build artifacts inside
+  `packaging/` instead of scattering `build/` and `dist/` folders at
+  the repo root.
+
+## Per-platform notes
+
+PyInstaller **does not cross-compile**. To ship a Windows `.exe`, run
+the build on Windows; to ship a macOS `.app`, run it on macOS; same
+for Linux. Apple Silicon builds run on Apple Silicon; Intel builds
+need an Intel Mac (or `arch -x86_64` + an x86_64 Python).
+
+### macOS code signing and notarization
+
+The unsigned `.app` will trigger Gatekeeper warnings. For distribution
+outside your own machine, sign and notarize it:
+
+```bash
+codesign --deep --force --sign "Developer ID Application: NAME (TEAMID)" \
+    packaging/dist/Raytracing.app
+xcrun notarytool submit packaging/dist/Raytracing.app \
+    --apple-id you@example.com --team-id TEAMID --wait
+xcrun stapler staple packaging/dist/Raytracing.app
+```
+
+Without a Developer ID, users can still run the app by right-clicking
+and choosing *Open* on first launch.
+
+### Windows
+
+On Windows, replace `--windowed` with `--noconsole` (same effect), and
+consider `--icon app.ico` to set the executable icon. For a proper
+installer, wrap the `dist/Raytracing` folder with
+[Inno Setup](https://jrsoftware.org/isinfo.php) or NSIS.
+
+## Alternative: install from PyPI
+
+For technical users, the simplest "deployment" is still:
+
+```bash
+pip install raytracing mytk pyperclip
+python -m raytracing -a
+```
+
+Use the PyInstaller bundle when the audience cannot be expected to
+manage a Python install (students in a lecture hall, conference demos,
+collaborators on a locked-down workstation).


### PR DESCRIPTION
## Summary
- Documents how to bundle `python -m raytracing -a` into a double-clickable app using PyInstaller (`packaging/BUILD.md`).
- Adds a GitHub Actions workflow (`.github/workflows/build-app.yml`) that builds macOS, Windows, and Linux bundles on `v*` tag pushes or manual dispatch, and attaches the artifacts to the GitHub Release for tag pushes.
- Local macOS build verified: ~50s, ~270 MB `.app`, launches cleanly.

## Test plan
- [ ] After merge, trigger the workflow manually from the Actions tab and confirm all three jobs succeed.
- [ ] Download each artifact and verify the bundle launches on its target OS.
- [ ] Cut a throwaway tag (e.g. `v1.4.0-test`) and confirm artifacts attach to the Release, then delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)