### PR TITLE
Modernize PyPI publish workflow, bump Python floor to 3.10

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,5 +1,6 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# Builds and uploads the raytracing package to PyPI when a GitHub Release
+# is published. See https://docs.github.com/en/actions/publishing-packages/
+# publishing-python-packages.
 
 name: Upload Python Package
 
@@ -9,23 +10,28 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
       with:
-        python-version: '3.6'
-    - name: Install dependencies
+        fetch-depth: 0  # setuptools_scm needs full history + tags
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
+        pip install build twine
+
+    - name: Build sdist and wheel
+      run: python -m build
+
+    - name: Publish to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      run: twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ name = "raytracing"
 dynamic = ["version"]  
 description = "Simple optical ray tracing library to validate the design of an optical system."
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 
 authors = [
@@ -40,10 +40,6 @@ classifiers = [
   "Topic :: Education",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary
- Fixes the `Version 3.6 with arch x64 not found` error on the publish workflow by bumping to Python 3.11 and updating action versions.
- Switches from the removed `python setup.py sdist bdist_wheel` to `python -m build`.
- Raises `requires-python` to `>=3.10` (numpy 2.x and matplotlib 3.10 already require it) and drops dead 3.6–3.9 classifiers.

## Test plan
- [ ] Cut a throwaway pre-release tag and confirm `pythonpublish.yml` runs to completion (or dry-run the workflow).
- [ ] Confirm `pip install raytracing` still resolves on a clean 3.10 environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)