### PR TITLE
Bundle PIL submodules in PyInstaller build

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -40,7 +40,12 @@ jobs:
           pip install pyperclip pillow pyinstaller
 
       - name: Build with PyInstaller
+        # --collect-submodules PIL: mytk loads PIL.ImageDraw / PIL.ImageTk
+        # via importlib.import_module(), which PyInstaller's static analyzer
+        # cannot follow. Without this flag the bundled app prompts the user
+        # to "install the missing module 'ImageDraw'" on first launch.
         run: pyinstaller --windowed --name Raytracing --noconfirm
+             --collect-submodules PIL
              --distpath packaging/dist --workpath packaging/build
              raytracing/ui/raytracing_app.py
 

--- a/packaging/BUILD.md
+++ b/packaging/BUILD.md
@@ -27,6 +27,7 @@ From the repo root:
 
 ```bash
 pyinstaller --windowed --name Raytracing --noconfirm \
+    --collect-submodules PIL \
     --distpath packaging/dist --workpath packaging/build \
     raytracing/ui/raytracing_app.py
 ```
@@ -52,6 +53,11 @@ matplotlib, and scipy dominate).
 - `--distpath` / `--workpath` — keeps build artifacts inside
   `packaging/` instead of scattering `build/` and `dist/` folders at
   the repo root.
+- `--collect-submodules PIL` — `mytk` loads `PIL.ImageDraw` and
+  `PIL.ImageTk` via `importlib.import_module()`, which PyInstaller's
+  static analyzer cannot follow. Without this flag, the bundled app
+  prompts the user to "install the missing module 'ImageDraw'" on
+  first launch.
 
 ## Per-platform notes
 


### PR DESCRIPTION
## Summary
Adds `--collect-submodules PIL` to the PyInstaller invocation so the bundled app finds `PIL.ImageDraw` and `PIL.ImageTk`. Without this, `mytk` loads them dynamically via `importlib.import_module()` and the frozen app prompts the user to "install the missing module 'ImageDraw'" on first launch.

Verified locally: rebuilt `Raytracing.app`, launched cleanly with no missing-module prompt.

## Test plan
- [ ] Merge → tag `v1.4.2` → confirm released bundles launch without the ImageDraw prompt on macOS/Windows/Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)