### PR TITLE
Instantiate vendor catalog parts by name, auto-fill Properties

### DIFF
--- a/raytracing/ui/raytracing_app.py
+++ b/raytracing/ui/raytracing_app.py
@@ -21,6 +21,12 @@ import ast
 import inspect
 from numpy import linspace, isfinite
 from raytracing import *
+# Vendor catalogs — pull every catalog class into the module namespace
+# so the table can instantiate parts by name (e.g. "AC254_050_A()" with
+# no args) via globals() lookup in instantiate_element.
+from raytracing.thorlabs import *
+from raytracing.eo import *
+from raytracing.olympus import *
 import colorsys
 import pyperclip
 from contextlib import suppress
@@ -758,6 +764,24 @@ class RaytracingApp(App):
 
         return instance, signature_kwargs
 
+    def _describe_element(self, element):
+        # Short "f=..., diameter=..." string summarising an instantiated
+        # element. Used to populate the Properties cell after a catalog
+        # part is loaded so the user can see what they got. Only the
+        # values that are finite are shown. Both kwarg names match real
+        # constructor params for Lens / AchromatDoubletLens / Objective
+        # so editing one back into the cell behaves predictably.
+        parts = []
+        try:
+            f = element.effectiveFocalLengths()[0]
+            if isfinite(f):
+                parts.append(f"f={f:.1f}")
+        except Exception:
+            pass
+        if hasattr(element, "apertureDiameter") and isfinite(element.apertureDiameter):
+            parts.append(f"diameter={element.apertureDiameter:.1f}")
+        return ", ".join(parts)
+
     def get_path_from_ui(self, without_apertures=True, max_position=None):
         path = ImagingPath()
 
@@ -793,6 +817,19 @@ class RaytracingApp(App):
                 err.details = signature_kwargs
                 err.details["element"] = element
                 raise err
+
+            # Keep the Properties cell in sync with the instantiated
+            # element: after every successful instantiation, re-derive
+            # an "f=..., diameter=..." string and write it back if it
+            # changed. This means switching Element from one catalog
+            # part to another automatically refreshes Properties.
+            # Typed input like "f=50" gets normalised to "f=50.0" on
+            # the first refresh — same value, slightly different form.
+            description = self._describe_element(path_element)
+            if description and description != element["arguments"]:
+                updated = {k: v for k, v in element.items() if not k.startswith("__")}
+                updated["arguments"] = description
+                self.tableview.data_source.update_record(element["__uuid"], updated)
 
             next_z = float(element["position"])
 


### PR DESCRIPTION
## Summary
Two related changes so vendor catalog parts (Thorlabs, Edmund Optics, Olympus) are usable from the element table.

- Pull `raytracing.thorlabs`, `raytracing.eo`, `raytracing.olympus` into the `raytracing_app` module namespace. `instantiate_element` resolves the Element column string via `globals()[class_name]`; without the import-stars the ~330 catalog classes aren't reachable. Now the user can type `AC254_050_A`, `PN_33_922`, `XLUMPlanFLN20X`, etc. in the Element column with empty Properties and it instantiates.
- After every successful instantiation in `get_path_from_ui`, derive a short `f=..., diameter=...` string from the element and write it back to the Properties cell if it differs. Zero-arg catalog parts immediately show their actual focal length and aperture; switching Element from one catalog part to another refreshes Properties automatically on the next refresh.

Independent of #503 (drawing) and #505 (autocomplete). Can merge in any order.

## Test plan
- [x] Type `AC254_050_A` in the Element cell, leave Properties empty, confirm it loads and Properties shows `f=50.0, diameter=25.4`.
- [x] Change Element to `AC127_019_A`, confirm Properties refreshes to the new part's values.
- [x] Type `Lens(f=80)` — confirm the element instantiates and Properties shows `f=80.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)