### PR TITLE
Fix AttributeError when enabling principal rays

### DIFF
--- a/raytracing/ui/raytracing_app.py
+++ b/raytracing/ui/raytracing_app.py
@@ -501,24 +501,17 @@ class RaytracingApp(App):
 
     def create_all_traces(self, path):
         if self.show_principal_rays:
+            basis = DynamicBasis(self.coords, "basis")
             principal_ray = path.principalRay()
             if principal_ray is not None:
-                principal_raytrace = path.trace(principal_ray)
-                line_trace = self.create_line_from_raytrace(
-                    principal_raytrace,
-                    basis=DynamicBasis(self.coords, "basis"),
-                    color="green",
-                )
-                self.coords.place(line_trace, position=Point(0, 0))
-
-                axial_ray = path.axialRay()
-                axial_raytrace = path.trace(axial_ray)
-                line_trace = self.create_line_from_raytrace(
-                    axial_raytrace,
-                    basis=DynamicBasis(self.coords, "basis"),
-                    color="red",
-                )
-                self.coords.place(line_trace, position=Point(0, 0))
+                for raytrace, color in (
+                    (path.trace(principal_ray), "green"),
+                    (path.trace(path.axialRay()), "red"),
+                ):
+                    for segment in self.create_line_segments_from_raytrace(
+                        raytrace, basis=basis, color=color
+                    ):
+                        self.coords.place(segment, position=Point(0, 0))
 
         else:
             M = int(self.number_of_heights)


### PR DESCRIPTION
## Summary
Pre-existing bug: \`create_all_traces\` calls \`self.create_line_from_raytrace\` which doesn't exist — the working method is \`create_line_segments_from_raytrace\` which returns a list. Clicking the "Principal rays" radio therefore crashed the refresh with \`AttributeError\`.

Rewire the principal-rays branch to iterate over the segments list (matches the custom-rays path below), and collapse the duplicate principal/axial blocks into a for loop while I'm here.

## Test plan
- [ ] Launch the app with the default Lens scene.
- [ ] Click "Principal rays" — confirm no crash, green (principal) and red (axial) rays appear on the canvas.
- [ ] Click "Custom rays" — confirm the coloured ray fan still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)