### PR TITLE
Fix results table: crashes, magnification gating, z-tracking for thick elements

### DIFF
--- a/raytracing/ui/raytracing_app.py
+++ b/raytracing/ui/raytracing_app.py
@@ -8,6 +8,7 @@ try:
     from mytk.canvasview import *
     from mytk.dataviews import *
     from mytk.entries import CellEntry
+    from mytk.tabulardata import PostponeChangeCalls
     from mytk.vectors import Point, PointDefault, DynamicBasis
     from mytk.labels import Label
     from mytk.notificationcenter import NotificationCenter
@@ -1335,7 +1336,8 @@ class RaytracingApp(App):
             if description and description != element["arguments"]:
                 updated = {k: v for k, v in element.items() if not k.startswith("__")}
                 updated["arguments"] = description
-                self.tableview.data_source.update_record(element["__uuid"], updated)
+                with PostponeChangeCalls(self.tableview.data_source):
+                    self.tableview.data_source.update_record(element["__uuid"], updated)
 
             next_z = float(element["position"])
 
@@ -1343,7 +1345,7 @@ class RaytracingApp(App):
 
             path.append(Space(d=delta))
             path.append(path_element)
-            z += delta
+            z += delta + path_element.L
 
         if max_position is not None:
             if path.L < max_position:
@@ -1474,10 +1476,10 @@ path.display(rays=rays)
                       if isfinite(p.fieldOfView()) else "Infinite [no FS]"),
         ("Magnification [Transverse]",
             lambda p: f"{p.magnification()[0]:.2f}"
-                      if isfinite(p.fieldOfView()) else "Inexistent"),
+                      if p.magnification()[0] is not None else "Inexistent"),
         ("Magnification [Angular]",
             lambda p: f"{p.magnification()[1]:.2f}"
-                      if isfinite(p.fieldOfView()) else "Inexistent"),
+                      if p.magnification()[1] is not None else "Inexistent"),
     ]
 
     def calculate_imaging_path_results(self, imaging_path):
@@ -1493,9 +1495,11 @@ path.display(rays=rays)
             return
 
         for label, get_value in self.RESULT_ROWS:
-            data_source.append_record(
-                {"property": label, "value": get_value(imaging_path)}
-            )
+            try:
+                value = get_value(imaging_path)
+            except Exception:
+                value = "N/A"
+            data_source.append_record({"property": label, "value": value})
 
         self.results_tableview.sort_column(column_name="property")
 


### PR DESCRIPTION
## Summary
Three fixes in the results table and path construction:

1. **try/except per RESULT_ROWS row** — `magnification()` returns `(None, None)` when `B != 0` (transient degenerate path during edits). Formatting `None` with `:.2f` raised `TypeError`. Failed rows now show "N/A".

2. **Magnification gating** — was gated on `isfinite(fieldOfView())`, which is `False` whenever there's no field stop, even though magnification is perfectly defined (depends on `B=0`, not stops). A bare `Lens(f=100)` showed "Inexistent" despite magnification being `-1.0`. Now gated on `magnification()[i] is not None`.

3. **z-tracking for thick elements** — `get_path_from_ui` advanced `z` by `delta` only, ignoring the element's own thickness (`path_element.L`). For thick elements like doublets, the `Space` before the next element was too long by one `element.L`, shifting the image plane and making `isImaging` return `False`. Fix: `z += delta + path_element.L`. This was always latent but never triggered because the original table only had thin `Lens` and `Aperture` (L=0).

Also wraps `_describe_element`'s `update_record` in `PostponeChangeCalls` to batch the notification cleanly.

## Test plan
- [ ] Default `Lens(f=100)` scene: magnification should show `-1.00`, not "Inexistent".
- [ ] `AC254_100_B` at z=200 + `Aperture(diameter=2.54)` at z=399: magnification should show `≈ -1.00`, image position `≈ 403`.
- [ ] Move the aperture around — magnification should stay correct, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)